### PR TITLE
Fix scroll to top after Location() if url has an anchor

### DIFF
--- a/src/Scripts/hydro.js
+++ b/src/Scripts/hydro.js
@@ -43,10 +43,6 @@
         let newTitle = doc.querySelector('head>title');
         element.innerHTML = newContent.innerHTML;
 
-        if (selector === 'body') {
-          window.scrollTo(0, 0);
-        }
-
         if (newTitle) {
           document.title = newTitle.textContent;
         }
@@ -54,6 +50,11 @@
         if (push) {
           history.pushState({}, '', url);
         }
+
+        if (selector === 'body' && !window.location.hash) {
+            window.scrollTo(0, 0);
+        }
+
       }
     } catch (error) {
       if (error.message === 'Request stopped') {


### PR DESCRIPTION
Current behavior:
`hydro.js` scrolls the html document to top after partially reloading its body with `Location()`, this creates a bug when the  target URL contains an anchor, resulting in:

* browser scrolls to anchor as requested by developer
* hydro.js scrolls back to top, breaking navigation logic

The proposed fix does the following:
* pushes the URL state to browser history before the check
* checks if the new pushed URL contains an anchor and scrolls to top only if not
