### PR TITLE
Pack of changes to pick from

### DIFF
--- a/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Configuration/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Hydro.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Hydro.Configuration;
@@ -20,6 +22,11 @@ public static class ServiceCollectionExtensions
         options?.Invoke(hydroOptions);
         services.AddSingleton(hydroOptions);
         services.TryAddSingleton<IPersistentState, PersistentState>();
+
+        services.AddScoped<ICookieManager, CookieManager>();
+        services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        services.AddDataProtection();
+
         return services;
     }
 }

--- a/src/Hydro.csproj
+++ b/src/Hydro.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Krzysztof Jeske</Authors>
     <Build>$([System.DateTime]::op_Subtraction($([System.DateTime]::get_Now().get_Date()),$([System.DateTime]::new(2000,1,1))).get_TotalDays())</Build>

--- a/src/HydroComponent.cs
+++ b/src/HydroComponent.cs
@@ -26,1185 +26,1185 @@ namespace Hydro;
 public abstract class HydroComponent : ViewComponent
 {
 
-	private string _componentId;
-	private bool _skipOutput;
-
-	private readonly ConcurrentDictionary<CacheKey, object> _requestCache = new();
-	private static readonly ConcurrentDictionary<CacheKey, object> PersistentCache = new();
-
-	private static readonly ConcurrentDictionary<Type, List<HydroPoll>> Polls = new();
-
-	private readonly List<string> _clientScripts = new();
-	private readonly List<HydroComponentEvent> _dispatchEvents = new();
-	private readonly HashSet<HydroEventSubscription> _subscriptions = new();
-
-	private static readonly MethodInfo InvokeActionMethod = typeof(HydroComponent).GetMethod(nameof(InvokeAction), BindingFlags.Static | BindingFlags.NonPublic);
-	private static readonly MethodInfo InvokeActionAsyncMethod = typeof(HydroComponent).GetMethod(nameof(InvokeActionAsync), BindingFlags.Static | BindingFlags.NonPublic);
-
-	public static readonly JsonSerializerSettings JsonSerializerSettings = new()
-	{
-		Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
-		ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-	};
-
-	private static readonly ConcurrentDictionary<Type, IHydroAuthorizationFilter[]> ComponentAuthorizationAttributes = new();
-	private HydroOptions _options;
-
-	/// <summary>
-	/// Provides indication if ModelState is valid
-	/// </summary>
-	protected bool IsValid { get; private set; }
-
-	/// <summary>
-	/// Provides component's key value
-	/// </summary>
-	protected string Key { get; private set; }
-
-	/// <summary>
-	/// Provides list of already accessed component's properties  
-	/// </summary>
-	public HashSet<string> TouchedProperties { get; set; } = new();
-
-	/// <summary>
-	/// Determines if the whole model was accessed already
-	/// </summary>
-	public bool IsModelTouched { get; set; }
-
-	/// <summary>
-	/// Determines if the current execution is related to the component mounting
-	/// </summary>
-	[Transient]
-	public bool IsMount { get; set; }
-
-	/// <summary>
-	/// Unique component identifier
-	/// </summary>
-	public string ComponentId => _componentId;
-
-	/// <summary />
-	public HydroComponent()
-	{
-		Subscribe<HydroBind>(data => SetPropertyValue(data.Name, data.Value));
-
-		ConfigurePolls();
-	}
-
-	private void ConfigurePolls()
-	{
-		var componentType = GetType();
-
-		if (Polls.ContainsKey(componentType))
-		{
-			return;
-		}
-
-		var methods = componentType
-			.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-			.Where(m => m.DeclaringType != typeof(HydroComponent))
-			.Select(m => (Method: m, Attribute: m.GetCustomAttribute<PollAttribute>()))
-			.Where(m => m.Attribute != null)
-			.Select(m => (m.Method, m.Attribute, ParametersCount: m.Method.GetParameters().Length))
-			.ToList();
-
-		if (methods.Any(p => p.Method.GetBaseDefinition() != p.Method))
-		{
-			throw new InvalidOperationException("Poll can be defined only on custom actions");
-		}
-
-		if (methods.Any(p => p.ParametersCount != 0))
-		{
-			throw new InvalidOperationException("Poll can be defined only on actions without parameters");
-		}
-
-		if (methods.Any(p => p.Attribute.Interval <= 0))
-		{
-			throw new InvalidOperationException("Polling's interval is invalid");
-		}
-
-		var polls = methods
-			.Select(p => new HydroPoll(p.Method.Name, TimeSpan.FromMilliseconds(p.Attribute.Interval)))
-			.ToList();
-
-		Polls.TryAdd(componentType, polls);
-	}
-
-	/// <summary>
-	/// Implementation of ViewComponent's InvokeAsync method
-	/// </summary>
-	/// <param name="parameters">Parameters</param>
-	/// <param name="key">Key</param>
-	public async Task<IHtmlContent> InvokeAsync(object parameters = null, string key = null)
-	{
-		var componentHtml = string.Empty;
-		if (ShouldRender())
-		{
-			await SetParametersAsync(parameters);
-
-			ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = null;
-			Key = key;
-
-			var persistentState = HttpContext.RequestServices.GetService<IPersistentState>();
-
-			_options = HttpContext.RequestServices.GetService<HydroOptions>();
-
-			if (persistentState == null || _options == null)
-			{
-				throw new ApplicationException("Hydro have not been initialized");
-			}
-
-			var firstRender = !IsMount;
-
-			try
-			{
-				//we need to for async threads called upon Dispatch, otherwise could just crash silently
-				componentHtml = HttpContext.IsHydro(excludeBoosted: true)
-					? await RenderOnlineComponent(persistentState)
-					: await RenderStaticComponent(persistentState);
-			}
-			catch (Exception e)
-			{
-				HandleError(e);
-			}
-
-			await OnAfterRenderAsync(firstRender);
-		}
-
-		return new HtmlString(componentHtml);
-	}
-
-	public virtual void HandleError(Exception e)
-	{
-		var message = $"{e.Message} {e.StackTrace}";
-		Debug.WriteLine(message);
-		Dispatch(new UnhandledHydroError(message, e), Scope.Global);
-	}
-
-	/// <summary>
-	/// Method invoked after each time the component has been rendered.
-	/// </summary>
-	/// <param name="firstRender">
-	/// Set to <c>true</c> if this is the first time it was rendered
-	/// </param>
-	protected virtual Task OnAfterRenderAsync(bool firstRender)
-		=> Task.CompletedTask;
-
-	/// <summary>
-	/// Subscribes to a Hydro event
-	/// </summary>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Subscribe<TEvent>(Func<string> subject = null) =>
-		_subscriptions.Add(new HydroEventSubscription
-		{
-			EventName = GetFullTypeName(typeof(TEvent)),
-			SubjectRetriever = subject,
-			Action = (TEvent _) => { }
-		});
-
-	/// <summary>
-	/// Subscribes to a Hydro event
-	/// </summary>
-	/// <param name="action">Action to execute when event occurs</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Subscribe<TEvent>(Action<TEvent> action) =>
-		_subscriptions.Add(new HydroEventSubscription
-		{
-			EventName = GetFullTypeName(typeof(TEvent)),
-			Action = action
-		});
-
-	/// <summary>
-	/// Subscribes to a Hydro event
-	/// </summary>
-	/// <param name="subject">Subject</param>
-	/// <param name="action">Action to execute when event occurs</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Subscribe<TEvent>(Func<string> subject, Action<TEvent> action) =>
-		_subscriptions.Add(new HydroEventSubscription
-		{
-			EventName = GetFullTypeName(typeof(TEvent)),
-			SubjectRetriever = subject,
-			Action = action
-		});
-
-	private static string GetFullTypeName(Type type) =>
-		type.DeclaringType != null
-			? type.DeclaringType.Name + "+" + type.Name
-			: type.Name;
-
-	/// <summary>
-	/// Subscribes to a Hydro event
-	/// </summary>
-	/// <param name="action">Action to execute when event occurs</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Subscribe<TEvent>(Func<TEvent, Task> action) =>
-		_subscriptions.Add(new HydroEventSubscription
-		{
-			EventName = GetFullTypeName(typeof(TEvent)),
-			Action = action
-		});
-
-	/// <summary>
-	/// Subscribes to a Hydro event
-	/// </summary>
-	/// <param name="subject">Subject</param>
-	/// <param name="action">Action to execute when event occurs</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Subscribe<TEvent>(Func<string> subject, Func<TEvent, Task> action) =>
-		_subscriptions.Add(new HydroEventSubscription
-		{
-			EventName = GetFullTypeName(typeof(TEvent)),
-			Action = action,
-			SubjectRetriever = subject
-		});
-
-	/// <summary>
-	/// Unsubscribe from a Hydro event
-	/// </summary>
-	/// <typeparam name="TEvent"></typeparam>
-	public void Unsubscribe<TEvent>()
-	{
-		var found = _subscriptions.RemoveWhere(x => x.EventName == typeof(TEvent).Name);
-	}
-
-	/// <summary>
-	/// Triggers a Hydro event
-	/// </summary>
-	/// <param name="data">Data to pass</param>
-	/// <param name="scope">Scope of the event</param>
-	/// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Dispatch<TEvent>(TEvent data, Scope scope = Scope.Parent, bool asynchronous = false) =>
-		Dispatch(GetFullTypeName(typeof(TEvent)), data, scope, asynchronous);
-
-	/// <summary>
-	/// Triggers a Hydro event
-	/// </summary>
-	/// <param name="name">Name of the event</param>
-	/// <param name="data">Data to pass</param>
-	/// <param name="scope">Scope of the event</param>
-	/// <param name="subject">Subject</param>
-	/// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void Dispatch<TEvent>(string name, TEvent data, Scope scope = Scope.Parent, bool asynchronous = false, string subject = null)
-	{
-		var operationId = !asynchronous && HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
-			? incomingOperationId.First()
-			: Guid.NewGuid().ToString("N");
-
-		_dispatchEvents.Add(new HydroComponentEvent
-		{
-			Name = name,
-			Data = data,
-			Scope = scope.ToString().ToLower(),
-			Subject = subject,
-			OperationId = operationId
-		});
-	}
-
-	/// <summary>
-	/// Triggers a Hydro event in a global scope
-	/// </summary>
-	/// <param name="data">Data to pass</param>
-	/// <param name="subject">Subject</param>
-	/// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
-	/// <typeparam name="TEvent">Event type</typeparam>
-	public void DispatchGlobal<TEvent>(TEvent data, string subject = null, bool asynchronous = false) =>
-		Dispatch(GetFullTypeName(typeof(TEvent)), data, Scope.Global, asynchronous, subject);
-
-	/// <summary>
-	/// Provides actions that can be executed on client side
-	/// </summary>
-	public HydroClientActions Client { get; } = new();
-
-	/// <summary>
-	/// Triggered once the component is mounted
-	/// </summary>
-	public virtual Task MountAsync()
-	{
-		Mount();
-		return Task.CompletedTask;
-	}
-
-	/// <summary>
-	/// Triggered once the component is mounted
-	/// </summary>
-	public virtual void Mount()
-	{
-	}
-
-	/// <summary>
-	/// Triggered before each render
-	/// </summary>
-	public virtual Task RenderAsync()
-	{
-		Render();
-		return Task.CompletedTask;
-	}
-
-	/// <summary>
-	/// Returns a flag to indicate whether the component should render.
-	/// </summary>
-	/// <returns></returns>
-	protected virtual bool ShouldRender()
-		=> true;
-
-	/// <summary>
-	/// Triggered before each render
-	/// </summary>
-	public virtual void Render()
-	{
-	}
-
-	/// <summary>
-	/// Perform a redirect with page reload
-	/// </summary>
-	/// <param name="url">Destination URL</param>
-	public void Redirect(string url) =>
-		HttpContext.Response.HydroRedirect(url);
-
-	/// <summary>
-	/// Perform a redirect without page reload
-	/// </summary>
-	/// <param name="url">Destination URL</param>
-	/// <param name="payload">Payload for the destination components</param>
-	public void Location(string url, object payload = null) =>
-		HttpContext.Response.HydroLocation(url, payload);
-
-	/// <summary>
-	/// Perform a redirect without page reload, but intead of replacing the whole body replaces the specified element. Example "#renderBody" or "renderBody" etc..
-	/// </summary>
-	/// <param name="url"></param>
-	/// <param name="target"></param>
-	/// <param name="payload"></param>
-	public void Location(string url, string target, object payload = null) =>
-		HttpContext.Response.HydroLocation(url, target, payload);
-
-	/// <summary>
-	/// Cache value
-	/// </summary>
-	/// <param name="func">Value producer</param>
-	/// <param name="lifetime">Lifetime of the cached value</param>
-	/// <typeparam name="T">Type of the value</typeparam>
-	/// <returns>Produced value</returns>
-	protected Cache<T> Cache<T>(Func<T> func, CacheLifetime lifetime = CacheLifetime.Request)
-	{
-		var cache = lifetime == CacheLifetime.Request ? _requestCache : PersistentCache;
-
-		var cacheKey = new CacheKey(_componentId, func);
-		if (cache.TryGetValue(cacheKey, out var dic))
-		{
-			var value = (Cache<T>)dic;
-
-			if (!value.IsSet)
-			{
-				cache.Remove(cacheKey, out _);
-			}
-			else
-			{
-				return value;
-			}
-		}
-
-		var cacheValue = new Cache<T>(func);
-		cache.TryAdd(cacheKey, cacheValue);
-		return cacheValue;
-	}
-
-	private async Task<string> RenderOnlineComponent(IPersistentState persistentState) =>
-		DetermineRootComponent()
-			? await RenderOnlineRootComponent(persistentState)
-			: await RenderOnlineNestedComponent(persistentState);
-
-	private bool DetermineRootComponent()
-	{
-		if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.IsRootRendered, out _))
-		{
-			HttpContext.Items.TryAdd(HydroConsts.ContextItems.IsRootRendered, true);
-			return true;
-		}
-
-		return false;
-	}
-
-	private async Task<string> RenderOnlineRootComponent(IPersistentState persistentState)
-	{
-		var componentId = GetRootComponentId();
-		_componentId = componentId;
-
-		PopulateBaseModel(persistentState);
-		await PopulateRequestModel();
-		if (!await AuthorizeAsync())
-		{
-			return string.Empty;
-		}
-
-		await TriggerEvent();
-
-		ValidateTouched();
-
-		await TriggerMethod();
-
-		if (!_skipOutput)
-		{
-			await RenderAsync();
-		}
-
-		PopulateDispatchers();
-
-		PopulateClientScripts();
-
-		return !_skipOutput
-			? await GenerateComponentHtml(componentId, persistentState, false)
-			: string.Empty;
-	}
-
-	private async Task<string> RenderOnlineNestedComponent(IPersistentState persistentState)
-	{
-		var componentId = GenerateComponentId(Key);
-		_componentId = componentId;
-
-		if (IsComponentIdRendered(componentId))
-		{
-			return GetComponentPlaceholderTemplate(componentId);
-		}
-
-		if (!await AuthorizeAsync())
-		{
-			return string.Empty;
-		}
-
-		IsMount = true;
-		await MountAsync();
-		await RenderAsync();
-		return await GenerateComponentHtml(componentId, persistentState, true);
-	}
-
-	private static string GetComponentPlaceholderTemplate(string componentId) =>
-		$"<div id=\"{componentId}\" key=\"{componentId}\" hydro hydro-placeholder></div>";
-
-	private async Task<string> RenderStaticComponent(IPersistentState persistentState)
-	{
-		var componentId = GenerateComponentId(Key);
-		_componentId = componentId;
-
-		if (!await AuthorizeAsync())
-		{
-			return string.Empty;
-		}
-
-		IsMount = true;
-		await MountAsync();
-		await RenderAsync();
-		return await GenerateComponentHtml(componentId, persistentState, true);
-	}
-
-	private string GenerateComponentId(string key)
-	{
-		var parentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
-		var mainId = parentComponentId ?? $"{Guid.NewGuid():N}";
-		var typeName = GetType().Name;
-
-
-		var generateComponentId = Hash($"{mainId}-{typeName}-{key}");
-		return generateComponentId;
-	}
-
-	private async Task<string> GenerateComponentHtml(string componentId, IPersistentState persistentState, bool isStatic)
-	{
-		var previousParentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
-		HttpContext.Items[HydroConsts.Component.ParentComponentId] = componentId;
-
-		var componentHtmlDocument = await GetComponentHtml();
-
-		HttpContext.Items[HydroConsts.Component.ParentComponentId] = previousParentComponentId;
-
-		var root = componentHtmlDocument.DocumentNode;
-
-		if (root.ChildNodes.Count(n => n.NodeType == HtmlNodeType.Element) != 1)
-		{
-			throw new InvalidOperationException("The wire component must have only one root element.");
-		}
-
-		var rootElement = root.ChildNodes.First(n => n.NodeType == HtmlNodeType.Element);
-
-		rootElement.SetAttributeValue("id", componentId);
-		rootElement.SetAttributeValue("key", componentId);
-		rootElement.SetAttributeValue("hydro-name", GetType().Name);
-		rootElement.SetAttributeValue("x-data", "hydro");
-		var hydroAttribute = rootElement.SetAttributeValue("hydro", null);
-		hydroAttribute.QuoteType = AttributeValueQuote.WithoutValue;
-
-		if (Polls.TryGetValue(GetType(), out var polls))
-		{
-			for (var i = 0; i < polls.Count; i++)
-			{
-				rootElement.AppendChild(GetPollScript(componentHtmlDocument, polls[i], i));
-			}
-		}
-
-		rootElement.AppendChild(GetModelScript(componentHtmlDocument, componentId, persistentState));
-
-		foreach (var subscription in _subscriptions)
-		{
-			rootElement.AppendChild(GetEventSubscriptionScript(componentHtmlDocument, subscription));
-		}
-
-		if (isStatic)
-		{
-			foreach (var script in _clientScripts)
-			{
-				rootElement.AppendChild(GetStaticScript(componentHtmlDocument, script));
-			}
-		}
-
-		return rootElement.OuterHtml;
-	}
-
-	private async Task BindModel(IFormCollection formCollection)
-	{
-		if (!IsModelTouched)
-		{
-			if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out _))
-			{
-				IsModelTouched = true;
-			}
-			else
-			{
-				foreach (var item in formCollection)
-				{
-					TouchedProperties.Add(item.Key);
-				}
-			}
-		}
-
-		foreach (var pair in formCollection)
-		{
-			var setter = PropertyInjector.GetPropertySetter(this, pair.Key, pair.Value);
-			var propertyPath = PropertyPath.ExtractPropertyPath(pair.Key);
-
-			if (setter != null)
-			{
-				var value = setter.Value.Value == null
-					? null
-					: _options.ValueMappersDictionary.TryGetValue(setter.Value.Value.GetType(), out var mapper)
-						? await mapper.Map(setter.Value.Value)
-						: setter.Value.Value;
-
-				setter.Value.Setter(value);
-				await BindAsync(propertyPath, value);
-			}
-			else
-			{
-				await BindAsync(propertyPath, null);
-			}
-		}
-
-		foreach (var file in formCollection.Files)
-		{
-			var setter = PropertyInjector.GetPropertySetter(this, file.Name, file);
-			var propertyPath = PropertyPath.ExtractPropertyPath(file.Name);
-
-			if (setter != null)
-			{
-				setter.Value.Setter(file);
-				await BindAsync(propertyPath, file);
-			}
-			else
-			{
-				await BindAsync(propertyPath, null);
-			}
-		}
-	}
-
-	/// <summary>
-	/// Applies value to a component
-	/// </summary>
-	/// <param name="path">Path to the value</param>
-	/// <param name="value">Value</param>
-	public async Task SetPropertyValue(string path, object value)
-	{
-		PropertyInjector.SetPropertyValue(this, path, value);
-		TouchedProperties.Add(path);
-		await BindAsync(PropertyPath.ExtractPropertyPath(path), value);
-	}
-
-	/// <summary>
-	/// Triggered when a property is updated from the client
-	/// </summary>
-	/// <param name="property">Property path</param>
-	/// <param name="value">New value</param>
-	public virtual void Bind(PropertyPath property, object value)
-	{
-	}
-
-	/// <summary>
-	/// Triggered when a property is updated from the client
-	/// </summary>
-	/// <param name="property">Property path</param>
-	/// <param name="value">New value</param>
-	public virtual Task BindAsync(PropertyPath property, object value)
-	{
-		Bind(property, value);
-		return Task.CompletedTask;
-	}
-
-	private HtmlNode GetModelScript(HtmlDocument document, string id, IPersistentState persistentState)
-	{
-		var scriptNode = document.CreateElement("script");
-		scriptNode.SetAttributeValue("type", "text/hydro");
-		scriptNode.SetAttributeValue("data-id", id);
-		var serializeDeclaredProperties = PropertyInjector.SerializeDeclaredProperties(GetType(), this);
-		var model = persistentState.Protect(serializeDeclaredProperties);
-		scriptNode.AppendChild(document.CreateTextNode(model));
-		return scriptNode;
-	}
-
-	private HtmlNode GetEventSubscriptionScript(HtmlDocument document, HydroEventSubscription subscription)
-	{
-		var eventData = new
-		{
-			name = subscription.EventName,
-			subject = subscription.SubjectRetriever?.Invoke(),
-			path = $"/hydro/{GetType().Name}/event".ToLower()
-		};
-
-		var scriptNode = document.CreateElement("script");
-		scriptNode.SetAttributeValue("key", $"R{Guid.NewGuid():N}");
-		scriptNode.SetAttributeValue("type", "text/hydro");
-		scriptNode.SetAttributeValue("hydro-event", "true");
-		scriptNode.SetAttributeValue("x-data", "");
-		scriptNode.SetAttributeValue("x-on-hydro-event", JsonConvert.SerializeObject(eventData, JsonSerializerSettings));
-		return scriptNode;
-	}
-
-	private HtmlNode GetPollScript(HtmlDocument document, HydroPoll poll, int index)
-	{
-		var scriptNode = document.CreateElement("script");
-		scriptNode.SetAttributeValue($"x-hydro-polling.{poll.Interval.TotalMilliseconds}ms._{index}", poll.Action);
-		scriptNode.SetAttributeValue("type", "text/hydro");
-		return scriptNode;
-	}
-
-	private HtmlNode GetStaticScript(HtmlDocument document, string script)
-	{
-		var scriptNode = document.CreateElement("script");
-		scriptNode.SetAttributeValue("hydro-js", "true");
-		scriptNode.SetAttributeValue("type", "text/hydro");
-		scriptNode.InnerHtml = script;
-		return scriptNode;
-	}
-
-	private void PopulateDispatchers()
-	{
-		if (!_dispatchEvents.Any())
-		{
-			return;
-		}
-
-		var data = _dispatchEvents
-			.Select(e => new
-			{
-				name = e.Name,
-				data = Base64.Serialize(e.Data),
-				scope = e.Scope,
-				subject = e.Subject,
-				operationId = e.OperationId
-			})
-			.ToList();
-
-		HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Trigger, JsonConvert.SerializeObject(data, JsonSerializerSettings));
-	}
-
-	private void PopulateClientScripts()
-	{
-		if (!_clientScripts.Any())
-		{
-			return;
-		}
-
-		HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Scripts, JsonConvert.SerializeObject(_clientScripts, JsonSerializerSettings));
-
-		_clientScripts.Clear();
-	}
-
-	private bool IsComponentIdRendered(string componentId)
-	{
-		var renderedComponentIds = (string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds];
-		return renderedComponentIds.Contains(componentId);
-	}
-
-	private async Task TriggerMethod()
-	{
-		if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out var method)
-			|| method is not string methodValue || string.IsNullOrWhiteSpace(methodValue))
-		{
-			return;
-		}
-
-		var methodInfos = GetType()
-			.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-
-		var requestParameters = (IDictionary<string, object>)HttpContext.Items[HydroConsts.ContextItems.Parameters];
-
-		var methodInfo = methodInfos.FirstOrDefault(m =>
-			string.Equals(m.Name, methodValue, StringComparison.OrdinalIgnoreCase)
-			&& m.GetParameters().Select(p => p.Name).SequenceEqual(requestParameters.Select(p => p.Key))
-		);
-
-		if (methodInfo == null)
-		{
-			return;
-		}
-
-		var methodParameters = methodInfo.GetParameters();
-		var methodAttributes = methodInfo.GetCustomAttributes();
-
-		if (requestParameters.Count != methodParameters.Length
-			|| requestParameters.Any(rp => !methodParameters.Any(mp => rp.Key == mp.Name)))
-		{
-			throw new InvalidOperationException("Wrong action parameters");
-		}
-
-		if (methodAttributes.Any(a => a.GetType() == typeof(SkipOutputAttribute)))
-		{
-			_skipOutput = true;
-			HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.SkipOutput, "True");
-		}
-
-		var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
-			? incomingOperationId.First()
-			: Guid.NewGuid().ToString("N");
-
-		HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
-
-		var orderedParameters = methodParameters
-			.Select(p =>
-			{
-				var requestParameter = requestParameters[p.Name!];
-
-				if (requestParameter == null)
-				{
-					return null;
-				}
-
-				var sourceType = requestParameter.GetType();
-
-				if (p.ParameterType == sourceType)
-				{
-					return requestParameter;
-				}
-
-				if (p.ParameterType.IsEnum)
-				{
-					return Enum.ToObject(p.ParameterType, requestParameter);
-				}
-
-				return TypeDescriptor.GetConverter(p.ParameterType).ConvertFrom(requestParameter);
-			})
-			.ToArray();
-
-		if (typeof(Task).IsAssignableFrom(methodInfo.ReturnType))
-		{
-			await (Task)methodInfo.Invoke(this, orderedParameters)!;
-		}
-		else
-		{
-			methodInfo.Invoke(this, orderedParameters);
-		}
-	}
-
-	/// <summary>
-	/// Get the payload transferred from previous page's component
-	/// </summary>
-	/// <typeparam name="T">Payload type</typeparam>
-	/// <returns>Payload</returns>
-	public T GetPayload<T>() =>
-		HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.Payload, out var payloadString)
-			? JsonConvert.DeserializeObject<T>(payloadString)
-			: default;
-
-	private async Task TriggerEvent()
-	{
-		if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.EventName, out var eventName)
-			|| eventName is not string eventNameValue || string.IsNullOrWhiteSpace(eventNameValue))
-		{
-			return;
-		}
-
-		var eventSubject = (string)HttpContext.Items[HydroConsts.ContextItems.EventSubject];
-		var subscriptions = _subscriptions
-			.Where(s => s.EventName == eventNameValue && (s.SubjectRetriever == null || s.SubjectRetriever() == eventSubject))
-			.ToList();
-
-		foreach (var subscription in subscriptions)
-		{
-			var methodInfo = subscription.Action.Method;
-			var parameters = methodInfo.GetParameters();
-			var parameterType = parameters.First().ParameterType;
-			var model = Base64.Deserialize((string)HttpContext.Items[HydroConsts.ContextItems.EventData], parameterType);
-
-			var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
-				? incomingOperationId.First()
-				: Guid.NewGuid().ToString("N");
-
-			HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
-
-			var isAsync = typeof(Task).IsAssignableFrom(methodInfo.ReturnType);
-
-			if (isAsync)
-			{
-				var method = InvokeActionAsyncMethod.MakeGenericMethod(parameterType);
-				await (Task)method.Invoke(null, new[] { subscription.Action, model })!;
-			}
-			else
-			{
-				var method = InvokeActionMethod.MakeGenericMethod(parameterType);
-				method.Invoke(null, new[] { subscription.Action, model });
-			}
-		}
-	}
-
-	private static void InvokeAction<T>(Delegate actionDelegate, T instance)
-	{
-		var action = actionDelegate as Action<T>;
-		action?.Invoke(instance);
-	}
-
-	private static Task InvokeActionAsync<T>(Delegate actionDelegate, T instance)
-	{
-		var action = actionDelegate as Func<T, Task>;
-		return action!.Invoke(instance);
-	}
-
-	private void PopulateBaseModel(IPersistentState persistentState)
-	{
-		if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.BaseModel, out var baseModel))
-		{
-			var unprotect = persistentState.Unprotect((string)baseModel);
-			JsonConvert.PopulateObject(unprotect, this);
-		}
-	}
-
-	private async Task PopulateRequestModel()
-	{
-		if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.RequestForm, out var requestForm))
-		{
-			await BindModel((IFormCollection)requestForm);
-		}
-	}
-
-	private string GetRootComponentId() =>
-		((string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds]).First();
-
-	private string GetViewPath() =>
-		ViewPath ?? GetViewPath(GetType());
-
-	/// <summary>
-	/// Get the view path based on the type
-	/// </summary>
-	protected string GetViewPath(Type type)
-	{
-		var assemblyName = type.Assembly.GetName().Name;
-		return $"{type.FullName!.Replace(assemblyName!, "~").Replace(".", "/")}.cshtml";
-	}
-
-	/// Get the view path based on the view name
-	protected string GetViewPath(string viewName)
-	{
-		var type = GetType();
-		return GetViewPath(type).Replace($"{type.Name}.cshtml", $"{viewName}.cshtml");
-	}
-
-	/// <summary>
-	/// Override this property if you want to use custom view path for the component
-	/// </summary>
-	public virtual string ViewPath => null;
-
-	private async Task<HtmlDocument> GetComponentHtml()
-	{
-		using var stream = new MemoryStream();
-		await using var writer = new StreamWriter(stream);
-
-		var previousWriter = ViewComponentContext.ViewContext.Writer;
-		ViewComponentContext.ViewContext.Writer = writer;
-		ViewComponentContext.ViewContext.CheckBoxHiddenInputRenderMode = CheckBoxHiddenInputRenderMode.None;
-
-		var result = View(GetViewPath(), this);
-
-		await result.ExecuteAsync(ViewComponentContext);
-		await writer.FlushAsync();
-
-		stream.Position = 0;
-		var htmlDocument = new HtmlDocument();
-		htmlDocument.Load(stream);
-		ViewComponentContext.ViewContext.Writer = previousWriter;
-		return htmlDocument;
-	}
-
-	/// <summary>
-	/// Method invoked when the component has received parameters from its parent in
-	/// the render tree, and the incoming values have been assigned to properties.
-	/// </summary>
-	/// <returns>A <see cref="Task"/> representing any asynchronous operation.</returns>
-	protected virtual Task OnParametersSetAsync()
-		=> Task.CompletedTask;
-
-	/// <summary>
-	/// Method invoked when the component has received parameters from its parent in
-	/// the render tree, and the incoming values have been assigned to properties.	/// </summary>
-	/// <param name="parameters"></param>
-	/// <returns></returns>
-	public virtual async Task SetParametersAsync(object parameters)
-	{
-		switch (parameters)
-		{
-		case null:
-		return;
-
-		case IDictionary<string, object> dictionary:
-		ApplyObjectFromDictionary(this, dictionary);
-		break;
-
-		default:
-		ApplyObject(this, parameters);
-		break;
-		}
-
-		await OnParametersSetAsync();
-	}
-
-	private void ApplyObject<T>(T target, object source)
-	{
-		if (source == null || target == null)
-		{
-			return;
-		}
-
-		var sourceType = source.GetType();
-		var targetType = target.GetType();
-
-		foreach (var sourceProperty in sourceType.GetProperties())
-		{
-			var targetProperty = targetType.GetProperty(sourceProperty.Name);
-
-			if (targetProperty == null || !targetProperty.CanWrite)
-			{
-				continue;
-			}
-
-			object sourceValue;
-
-			if (sourceProperty.PropertyType == targetProperty.PropertyType)
-			{
-				sourceValue = sourceProperty.GetValue(source);
-			}
-			else
-			{
-				try
-				{
-					var json = JsonConvert.SerializeObject(sourceProperty.GetValue(source), JsonSerializerSettings);
-					sourceValue = JsonConvert.DeserializeObject(json, targetProperty.PropertyType);
-				}
-				catch
-				{
-					throw new InvalidCastException($"Type mismatch in {sourceProperty.Name} parameter.");
-				}
-			}
-
-			targetProperty.SetValue(target, sourceValue);
-		}
-	}
-
-	private void ApplyObjectFromDictionary<T>(T target, IDictionary<string, object> source)
-	{
-		if (source == null || target == null)
-		{
-			return;
-		}
-
-		var targetType = target.GetType();
-
-		foreach (var sourceProperty in source)
-		{
-			var targetProperty = targetType.GetProperty(sourceProperty.Key, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-
-			if (targetProperty == null || !targetProperty.CanWrite)
-			{
-				continue;
-			}
-
-			var value = sourceProperty.Value;
-
-			if (value != null && !targetProperty.PropertyType.IsInstanceOfType(value))
-			{
-				throw new InvalidCastException($"Type mismatch in {sourceProperty.Key} parameter.");
-			}
-
-			targetProperty.SetValue(target, value);
-		}
-	}
-
-	/// <summary>
-	/// Validate the model state
-	/// </summary>
-	/// <returns>True if the state is valid</returns>
-	public bool Validate()
-	{
-		IsModelTouched = true;
-		return ValidateTouched();
-	}
-
-	private bool ValidateTouched()
-	{
-		ModelState.Clear();
-
-		var context = new ValidationContext(this, serviceProvider: HttpContext.RequestServices, items: null);
-		var validationResults = new List<ValidationResult>();
-		Validator.TryValidateObject(this, context, validationResults, true);
-		var extractValidationResults = ExtractValidationResults(validationResults);
-
-		foreach (var validationResult in extractValidationResults)
-		{
-			foreach (var memberName in validationResult.MemberNames)
-			{
-				if (IsModelTouched || TouchedProperties.Contains(memberName) || TouchedProperties.Any(p => p.StartsWith($"{memberName}.")))
-				{
-					ModelState.AddModelError(memberName, validationResult.ErrorMessage!);
-				}
-			}
-		}
-
-		IsValid = ModelState.IsValid;
-
-		return IsValid;
-	}
-
-	private static IEnumerable<ValidationResult> ExtractValidationResults(IEnumerable<ValidationResult> validationResults)
-	{
-		foreach (var result in validationResults)
-		{
-			yield return result;
-
-			if (result is ICompositeValidationResult compositeResult)
-			{
-				foreach (var innerResult in compositeResult.Results)
-				{
-					yield return innerResult;
-				}
-			}
-		}
-	}
-
-	private async Task<bool> AuthorizeAsync()
-	{
-		var type = GetType();
-
-		if (!ComponentAuthorizationAttributes.ContainsKey(type))
-		{
-			ComponentAuthorizationAttributes.TryAdd(type, type.GetCustomAttributes(true)
-				.Where(attr => attr is IHydroAuthorizationFilter)
-				.Cast<IHydroAuthorizationFilter>()
-				.ToArray());
-		}
-
-		foreach (var authorizationFilter in ComponentAuthorizationAttributes[type])
-		{
-			if (!await authorizationFilter.AuthorizeAsync(HttpContext, this))
-			{
-				if (HttpContext.IsHydro(excludeBoosted: true))
-				{
-					HttpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
-				}
-
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	/// Queue JS to be executed on client side upon rendering component
-	/// </summary>
-	/// <param name="script"></param>
-	public void ExecuteJs(string script)
-	{
-		_clientScripts.Add(script);
-	}
-
-	private static string Hash(string input) =>
-		$"W{Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(input)))}";
-
-
-	/// <summary>
-	/// Binds model with the request Form if any and updates ModelState. WIth optional preValidate you can transform/check model values before they go to validation and even add your own validation errors. Return value is equal to  ModelState.IsValid.
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	/// <param name="model"></param>
-	/// <param name="preValidate"></param>
-	/// <returns></returns>
-	public virtual async Task<bool> BindFormAndValidateAsync<T>(T model, Action<T, ModelStateDictionary> preValidate = null)
-	{
-		ModelState.Clear();
-		IsModelTouched = true;
-
-		var factory = HttpContext.RequestServices.GetRequiredService<IModelBinderFactory>();
-		var metadataProvider = HttpContext.RequestServices.GetRequiredService<IModelMetadataProvider>();
-		var modelMetadata = metadataProvider.GetMetadataForType(typeof(T));
-		var modelBinder = factory.CreateBinder(new ModelBinderFactoryContext
-		{
-			BindingInfo = new BindingInfo { BindingSource = BindingSource.Form },
-			Metadata = modelMetadata,
-			CacheToken = modelMetadata
-		});
-
-		var bindingInfo = new BindingInfo
-		{
-			BindingSource = BindingSource.Form
-		};
-
-		var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
-			ViewContext,
-			new CompositeValueProvider { new FormValueProvider(BindingSource.Form, HttpContext.Request.Form, CultureInfo.CurrentCulture) },
-			modelMetadata,
-			bindingInfo: bindingInfo,
-			modelName: typeof(T).Name);
-
-		modelBindingContext.Model = model;
-
-		await modelBinder.BindModelAsync(modelBindingContext);
-
-		preValidate?.Invoke(model, modelBindingContext.ModelState);
-
-		if (modelBindingContext.Result.IsModelSet)
-		{
-			var validationResults = new HashSet<ValidationResult>();
-			var isValid = Validator.TryValidateObject(model, new ValidationContext(model, HttpContext.RequestServices, null), validationResults, true);
-			if (!isValid)
-			{
-				foreach (var validationResult in validationResults)
-				{
-					foreach (var memberName in validationResult.MemberNames)
-					{
-						modelBindingContext.ModelState.AddModelError(memberName, validationResult.ErrorMessage);
-					}
-				}
-			}
-		}
-
-		if (!modelBindingContext.ModelState.IsValid)
-		{
-			foreach (var key in modelBindingContext.ModelState.Keys)
-			{
-				var values = modelBindingContext.ModelState[key];
-				if (values != null)
-					foreach (var error in values.Errors)
-					{
-						ModelState.AddModelError(key, error.ErrorMessage);
-					}
-			}
-		}
-
-		return ModelState.IsValid;
-	}
+    private string _componentId;
+    private bool _skipOutput;
+
+    private readonly ConcurrentDictionary<CacheKey, object> _requestCache = new();
+    private static readonly ConcurrentDictionary<CacheKey, object> PersistentCache = new();
+
+    private static readonly ConcurrentDictionary<Type, List<HydroPoll>> Polls = new();
+
+    private readonly List<string> _clientScripts = new();
+    private readonly List<HydroComponentEvent> _dispatchEvents = new();
+    private readonly HashSet<HydroEventSubscription> _subscriptions = new();
+
+    private static readonly MethodInfo InvokeActionMethod = typeof(HydroComponent).GetMethod(nameof(InvokeAction), BindingFlags.Static | BindingFlags.NonPublic);
+    private static readonly MethodInfo InvokeActionAsyncMethod = typeof(HydroComponent).GetMethod(nameof(InvokeActionAsync), BindingFlags.Static | BindingFlags.NonPublic);
+
+    public static JsonSerializerSettings JsonSerializerSettings = new()
+    {
+        Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+    };
+
+    private static readonly ConcurrentDictionary<Type, IHydroAuthorizationFilter[]> ComponentAuthorizationAttributes = new();
+    private HydroOptions _options;
+
+    /// <summary>
+    /// Provides indication if ModelState is valid
+    /// </summary>
+    protected bool IsValid { get; private set; }
+
+    /// <summary>
+    /// Provides component's key value
+    /// </summary>
+    protected string Key { get; private set; }
+
+    /// <summary>
+    /// Provides list of already accessed component's properties  
+    /// </summary>
+    public HashSet<string> TouchedProperties { get; set; } = new();
+
+    /// <summary>
+    /// Determines if the whole model was accessed already
+    /// </summary>
+    public bool IsModelTouched { get; set; }
+
+    /// <summary>
+    /// Determines if the current execution is related to the component mounting
+    /// </summary>
+    [Transient]
+    public bool IsMount { get; set; }
+
+    /// <summary>
+    /// Unique component identifier
+    /// </summary>
+    public string ComponentId => _componentId;
+
+    /// <summary />
+    public HydroComponent()
+    {
+        Subscribe<HydroBind>(data => SetPropertyValue(data.Name, data.Value));
+
+        ConfigurePolls();
+    }
+
+    private void ConfigurePolls()
+    {
+        var componentType = GetType();
+
+        if (Polls.ContainsKey(componentType))
+        {
+            return;
+        }
+
+        var methods = componentType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.DeclaringType != typeof(HydroComponent))
+            .Select(m => (Method: m, Attribute: m.GetCustomAttribute<PollAttribute>()))
+            .Where(m => m.Attribute != null)
+            .Select(m => (m.Method, m.Attribute, ParametersCount: m.Method.GetParameters().Length))
+            .ToList();
+
+        if (methods.Any(p => p.Method.GetBaseDefinition() != p.Method))
+        {
+            throw new InvalidOperationException("Poll can be defined only on custom actions");
+        }
+
+        if (methods.Any(p => p.ParametersCount != 0))
+        {
+            throw new InvalidOperationException("Poll can be defined only on actions without parameters");
+        }
+
+        if (methods.Any(p => p.Attribute.Interval <= 0))
+        {
+            throw new InvalidOperationException("Polling's interval is invalid");
+        }
+
+        var polls = methods
+            .Select(p => new HydroPoll(p.Method.Name, TimeSpan.FromMilliseconds(p.Attribute.Interval)))
+            .ToList();
+
+        Polls.TryAdd(componentType, polls);
+    }
+
+    /// <summary>
+    /// Implementation of ViewComponent's InvokeAsync method
+    /// </summary>
+    /// <param name="parameters">Parameters</param>
+    /// <param name="key">Key</param>
+    public async Task<IHtmlContent> InvokeAsync(object parameters = null, string key = null)
+    {
+        var componentHtml = string.Empty;
+        if (ShouldRender())
+        {
+            await SetParametersAsync(parameters);
+
+            ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = null;
+            Key = key;
+
+            var persistentState = HttpContext.RequestServices.GetService<IPersistentState>();
+
+            _options = HttpContext.RequestServices.GetService<HydroOptions>();
+
+            if (persistentState == null || _options == null)
+            {
+                throw new ApplicationException("Hydro have not been initialized");
+            }
+
+            var firstRender = !IsMount;
+
+            try
+            {
+                //we need to for async threads called upon Dispatch, otherwise could just crash silently
+                componentHtml = HttpContext.IsHydro(excludeBoosted: true)
+                    ? await RenderOnlineComponent(persistentState)
+                    : await RenderStaticComponent(persistentState);
+            }
+            catch (Exception e)
+            {
+                HandleError(e);
+            }
+
+            await OnAfterRenderAsync(firstRender);
+        }
+
+        return new HtmlString(componentHtml);
+    }
+
+    public virtual void HandleError(Exception e)
+    {
+        var message = $"{e.Message} {e.StackTrace}";
+        Debug.WriteLine(message);
+        Dispatch(new UnhandledHydroError(message, e), Scope.Global);
+    }
+
+    /// <summary>
+    /// Method invoked after each time the component has been rendered.
+    /// </summary>
+    /// <param name="firstRender">
+    /// Set to <c>true</c> if this is the first time it was rendered
+    /// </param>
+    protected virtual Task OnAfterRenderAsync(bool firstRender)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Subscribes to a Hydro event
+    /// </summary>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Subscribe<TEvent>(Func<string> subject = null) =>
+        _subscriptions.Add(new HydroEventSubscription
+        {
+            EventName = GetFullTypeName(typeof(TEvent)),
+            SubjectRetriever = subject,
+            Action = (TEvent _) => { }
+        });
+
+    /// <summary>
+    /// Subscribes to a Hydro event
+    /// </summary>
+    /// <param name="action">Action to execute when event occurs</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Subscribe<TEvent>(Action<TEvent> action) =>
+        _subscriptions.Add(new HydroEventSubscription
+        {
+            EventName = GetFullTypeName(typeof(TEvent)),
+            Action = action
+        });
+
+    /// <summary>
+    /// Subscribes to a Hydro event
+    /// </summary>
+    /// <param name="subject">Subject</param>
+    /// <param name="action">Action to execute when event occurs</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Subscribe<TEvent>(Func<string> subject, Action<TEvent> action) =>
+        _subscriptions.Add(new HydroEventSubscription
+        {
+            EventName = GetFullTypeName(typeof(TEvent)),
+            SubjectRetriever = subject,
+            Action = action
+        });
+
+    private static string GetFullTypeName(Type type) =>
+        type.DeclaringType != null
+            ? type.DeclaringType.Name + "+" + type.Name
+            : type.Name;
+
+    /// <summary>
+    /// Subscribes to a Hydro event
+    /// </summary>
+    /// <param name="action">Action to execute when event occurs</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Subscribe<TEvent>(Func<TEvent, Task> action) =>
+        _subscriptions.Add(new HydroEventSubscription
+        {
+            EventName = GetFullTypeName(typeof(TEvent)),
+            Action = action
+        });
+
+    /// <summary>
+    /// Subscribes to a Hydro event
+    /// </summary>
+    /// <param name="subject">Subject</param>
+    /// <param name="action">Action to execute when event occurs</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Subscribe<TEvent>(Func<string> subject, Func<TEvent, Task> action) =>
+        _subscriptions.Add(new HydroEventSubscription
+        {
+            EventName = GetFullTypeName(typeof(TEvent)),
+            Action = action,
+            SubjectRetriever = subject
+        });
+
+    /// <summary>
+    /// Unsubscribe from a Hydro event
+    /// </summary>
+    /// <typeparam name="TEvent"></typeparam>
+    public void Unsubscribe<TEvent>()
+    {
+        var found = _subscriptions.RemoveWhere(x => x.EventName == typeof(TEvent).Name);
+    }
+
+    /// <summary>
+    /// Triggers a Hydro event
+    /// </summary>
+    /// <param name="data">Data to pass</param>
+    /// <param name="scope">Scope of the event</param>
+    /// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Dispatch<TEvent>(TEvent data, Scope scope = Scope.Parent, bool asynchronous = false) =>
+        Dispatch(GetFullTypeName(typeof(TEvent)), data, scope, asynchronous);
+
+    /// <summary>
+    /// Triggers a Hydro event
+    /// </summary>
+    /// <param name="name">Name of the event</param>
+    /// <param name="data">Data to pass</param>
+    /// <param name="scope">Scope of the event</param>
+    /// <param name="subject">Subject</param>
+    /// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void Dispatch<TEvent>(string name, TEvent data, Scope scope = Scope.Parent, bool asynchronous = false, string subject = null)
+    {
+        var operationId = !asynchronous && HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
+            ? incomingOperationId.First()
+            : Guid.NewGuid().ToString("N");
+
+        _dispatchEvents.Add(new HydroComponentEvent
+        {
+            Name = name,
+            Data = data,
+            Scope = scope.ToString().ToLower(),
+            Subject = subject,
+            OperationId = operationId
+        });
+    }
+
+    /// <summary>
+    /// Triggers a Hydro event in a global scope
+    /// </summary>
+    /// <param name="data">Data to pass</param>
+    /// <param name="subject">Subject</param>
+    /// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
+    /// <typeparam name="TEvent">Event type</typeparam>
+    public void DispatchGlobal<TEvent>(TEvent data, string subject = null, bool asynchronous = false) =>
+        Dispatch(GetFullTypeName(typeof(TEvent)), data, Scope.Global, asynchronous, subject);
+
+    /// <summary>
+    /// Provides actions that can be executed on client side
+    /// </summary>
+    public HydroClientActions Client { get; } = new();
+
+    /// <summary>
+    /// Triggered once the component is mounted
+    /// </summary>
+    public virtual Task MountAsync()
+    {
+        Mount();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Triggered once the component is mounted
+    /// </summary>
+    public virtual void Mount()
+    {
+    }
+
+    /// <summary>
+    /// Triggered before each render
+    /// </summary>
+    public virtual Task RenderAsync()
+    {
+        Render();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Returns a flag to indicate whether the component should render.
+    /// </summary>
+    /// <returns></returns>
+    protected virtual bool ShouldRender()
+        => true;
+
+    /// <summary>
+    /// Triggered before each render
+    /// </summary>
+    public virtual void Render()
+    {
+    }
+
+    /// <summary>
+    /// Perform a redirect with page reload
+    /// </summary>
+    /// <param name="url">Destination URL</param>
+    public void Redirect(string url) =>
+        HttpContext.Response.HydroRedirect(url);
+
+    /// <summary>
+    /// Perform a redirect without page reload
+    /// </summary>
+    /// <param name="url">Destination URL</param>
+    /// <param name="payload">Payload for the destination components</param>
+    public void Location(string url, object payload = null) =>
+        HttpContext.Response.HydroLocation(url, payload);
+
+    /// <summary>
+    /// Perform a redirect without page reload, but intead of replacing the whole body replaces the specified element. Example "#renderBody" or "renderBody" etc..
+    /// </summary>
+    /// <param name="url"></param>
+    /// <param name="target"></param>
+    /// <param name="payload"></param>
+    public void Location(string url, string target, object payload = null) =>
+        HttpContext.Response.HydroLocation(url, target, payload);
+
+    /// <summary>
+    /// Cache value
+    /// </summary>
+    /// <param name="func">Value producer</param>
+    /// <param name="lifetime">Lifetime of the cached value</param>
+    /// <typeparam name="T">Type of the value</typeparam>
+    /// <returns>Produced value</returns>
+    protected Cache<T> Cache<T>(Func<T> func, CacheLifetime lifetime = CacheLifetime.Request)
+    {
+        var cache = lifetime == CacheLifetime.Request ? _requestCache : PersistentCache;
+
+        var cacheKey = new CacheKey(_componentId, func);
+        if (cache.TryGetValue(cacheKey, out var dic))
+        {
+            var value = (Cache<T>)dic;
+
+            if (!value.IsSet)
+            {
+                cache.Remove(cacheKey, out _);
+            }
+            else
+            {
+                return value;
+            }
+        }
+
+        var cacheValue = new Cache<T>(func);
+        cache.TryAdd(cacheKey, cacheValue);
+        return cacheValue;
+    }
+
+    private async Task<string> RenderOnlineComponent(IPersistentState persistentState) =>
+        DetermineRootComponent()
+            ? await RenderOnlineRootComponent(persistentState)
+            : await RenderOnlineNestedComponent(persistentState);
+
+    private bool DetermineRootComponent()
+    {
+        if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.IsRootRendered, out _))
+        {
+            HttpContext.Items.TryAdd(HydroConsts.ContextItems.IsRootRendered, true);
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task<string> RenderOnlineRootComponent(IPersistentState persistentState)
+    {
+        var componentId = GetRootComponentId();
+        _componentId = componentId;
+
+        PopulateBaseModel(persistentState);
+        await PopulateRequestModel();
+        if (!await AuthorizeAsync())
+        {
+            return string.Empty;
+        }
+
+        await TriggerEvent();
+
+        ValidateTouched();
+
+        await TriggerMethod();
+
+        if (!_skipOutput)
+        {
+            await RenderAsync();
+        }
+
+        PopulateDispatchers();
+
+        PopulateClientScripts();
+
+        return !_skipOutput
+            ? await GenerateComponentHtml(componentId, persistentState, false)
+            : string.Empty;
+    }
+
+    private async Task<string> RenderOnlineNestedComponent(IPersistentState persistentState)
+    {
+        var componentId = GenerateComponentId(Key);
+        _componentId = componentId;
+
+        if (IsComponentIdRendered(componentId))
+        {
+            return GetComponentPlaceholderTemplate(componentId);
+        }
+
+        if (!await AuthorizeAsync())
+        {
+            return string.Empty;
+        }
+
+        IsMount = true;
+        await MountAsync();
+        await RenderAsync();
+        return await GenerateComponentHtml(componentId, persistentState, true);
+    }
+
+    private static string GetComponentPlaceholderTemplate(string componentId) =>
+        $"<div id=\"{componentId}\" key=\"{componentId}\" hydro hydro-placeholder></div>";
+
+    private async Task<string> RenderStaticComponent(IPersistentState persistentState)
+    {
+        var componentId = GenerateComponentId(Key);
+        _componentId = componentId;
+
+        if (!await AuthorizeAsync())
+        {
+            return string.Empty;
+        }
+
+        IsMount = true;
+        await MountAsync();
+        await RenderAsync();
+        return await GenerateComponentHtml(componentId, persistentState, true);
+    }
+
+    private string GenerateComponentId(string key)
+    {
+        var parentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
+        var mainId = parentComponentId ?? $"{Guid.NewGuid():N}";
+        var typeName = GetType().Name;
+
+
+        var generateComponentId = Hash($"{mainId}-{typeName}-{key}");
+        return generateComponentId;
+    }
+
+    private async Task<string> GenerateComponentHtml(string componentId, IPersistentState persistentState, bool isStatic)
+    {
+        var previousParentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
+        HttpContext.Items[HydroConsts.Component.ParentComponentId] = componentId;
+
+        var componentHtmlDocument = await GetComponentHtml();
+
+        HttpContext.Items[HydroConsts.Component.ParentComponentId] = previousParentComponentId;
+
+        var root = componentHtmlDocument.DocumentNode;
+
+        if (root.ChildNodes.Count(n => n.NodeType == HtmlNodeType.Element) != 1)
+        {
+            throw new InvalidOperationException("The wire component must have only one root element.");
+        }
+
+        var rootElement = root.ChildNodes.First(n => n.NodeType == HtmlNodeType.Element);
+
+        rootElement.SetAttributeValue("id", componentId);
+        rootElement.SetAttributeValue("key", componentId);
+        rootElement.SetAttributeValue("hydro-name", GetType().Name);
+        rootElement.SetAttributeValue("x-data", "hydro");
+        var hydroAttribute = rootElement.SetAttributeValue("hydro", null);
+        hydroAttribute.QuoteType = AttributeValueQuote.WithoutValue;
+
+        if (Polls.TryGetValue(GetType(), out var polls))
+        {
+            for (var i = 0; i < polls.Count; i++)
+            {
+                rootElement.AppendChild(GetPollScript(componentHtmlDocument, polls[i], i));
+            }
+        }
+
+        rootElement.AppendChild(GetModelScript(componentHtmlDocument, componentId, persistentState));
+
+        foreach (var subscription in _subscriptions)
+        {
+            rootElement.AppendChild(GetEventSubscriptionScript(componentHtmlDocument, subscription));
+        }
+
+        if (isStatic)
+        {
+            foreach (var script in _clientScripts)
+            {
+                rootElement.AppendChild(GetStaticScript(componentHtmlDocument, script));
+            }
+        }
+
+        return rootElement.OuterHtml;
+    }
+
+    private async Task BindModel(IFormCollection formCollection)
+    {
+        if (!IsModelTouched)
+        {
+            if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out _))
+            {
+                IsModelTouched = true;
+            }
+            else
+            {
+                foreach (var item in formCollection)
+                {
+                    TouchedProperties.Add(item.Key);
+                }
+            }
+        }
+
+        foreach (var pair in formCollection)
+        {
+            var setter = PropertyInjector.GetPropertySetter(this, pair.Key, pair.Value);
+            var propertyPath = PropertyPath.ExtractPropertyPath(pair.Key);
+
+            if (setter != null)
+            {
+                var value = setter.Value.Value == null
+                    ? null
+                    : _options.ValueMappersDictionary.TryGetValue(setter.Value.Value.GetType(), out var mapper)
+                        ? await mapper.Map(setter.Value.Value)
+                        : setter.Value.Value;
+
+                setter.Value.Setter(value);
+                await BindAsync(propertyPath, value);
+            }
+            else
+            {
+                await BindAsync(propertyPath, null);
+            }
+        }
+
+        foreach (var file in formCollection.Files)
+        {
+            var setter = PropertyInjector.GetPropertySetter(this, file.Name, file);
+            var propertyPath = PropertyPath.ExtractPropertyPath(file.Name);
+
+            if (setter != null)
+            {
+                setter.Value.Setter(file);
+                await BindAsync(propertyPath, file);
+            }
+            else
+            {
+                await BindAsync(propertyPath, null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies value to a component
+    /// </summary>
+    /// <param name="path">Path to the value</param>
+    /// <param name="value">Value</param>
+    public async Task SetPropertyValue(string path, object value)
+    {
+        PropertyInjector.SetPropertyValue(this, path, value);
+        TouchedProperties.Add(path);
+        await BindAsync(PropertyPath.ExtractPropertyPath(path), value);
+    }
+
+    /// <summary>
+    /// Triggered when a property is updated from the client
+    /// </summary>
+    /// <param name="property">Property path</param>
+    /// <param name="value">New value</param>
+    public virtual void Bind(PropertyPath property, object value)
+    {
+    }
+
+    /// <summary>
+    /// Triggered when a property is updated from the client
+    /// </summary>
+    /// <param name="property">Property path</param>
+    /// <param name="value">New value</param>
+    public virtual Task BindAsync(PropertyPath property, object value)
+    {
+        Bind(property, value);
+        return Task.CompletedTask;
+    }
+
+    private HtmlNode GetModelScript(HtmlDocument document, string id, IPersistentState persistentState)
+    {
+        var scriptNode = document.CreateElement("script");
+        scriptNode.SetAttributeValue("type", "text/hydro");
+        scriptNode.SetAttributeValue("data-id", id);
+        var serializeDeclaredProperties = PropertyInjector.SerializeDeclaredProperties(GetType(), this);
+        var model = persistentState.Protect(serializeDeclaredProperties);
+        scriptNode.AppendChild(document.CreateTextNode(model));
+        return scriptNode;
+    }
+
+    private HtmlNode GetEventSubscriptionScript(HtmlDocument document, HydroEventSubscription subscription)
+    {
+        var eventData = new
+        {
+            name = subscription.EventName,
+            subject = subscription.SubjectRetriever?.Invoke(),
+            path = $"/hydro/{GetType().Name}/event".ToLower()
+        };
+
+        var scriptNode = document.CreateElement("script");
+        scriptNode.SetAttributeValue("key", $"R{Guid.NewGuid():N}");
+        scriptNode.SetAttributeValue("type", "text/hydro");
+        scriptNode.SetAttributeValue("hydro-event", "true");
+        scriptNode.SetAttributeValue("x-data", "");
+        scriptNode.SetAttributeValue("x-on-hydro-event", JsonConvert.SerializeObject(eventData, JsonSerializerSettings));
+        return scriptNode;
+    }
+
+    private HtmlNode GetPollScript(HtmlDocument document, HydroPoll poll, int index)
+    {
+        var scriptNode = document.CreateElement("script");
+        scriptNode.SetAttributeValue($"x-hydro-polling.{poll.Interval.TotalMilliseconds}ms._{index}", poll.Action);
+        scriptNode.SetAttributeValue("type", "text/hydro");
+        return scriptNode;
+    }
+
+    private HtmlNode GetStaticScript(HtmlDocument document, string script)
+    {
+        var scriptNode = document.CreateElement("script");
+        scriptNode.SetAttributeValue("hydro-js", "true");
+        scriptNode.SetAttributeValue("type", "text/hydro");
+        scriptNode.InnerHtml = script;
+        return scriptNode;
+    }
+
+    private void PopulateDispatchers()
+    {
+        if (!_dispatchEvents.Any())
+        {
+            return;
+        }
+
+        var data = _dispatchEvents
+            .Select(e => new
+            {
+                name = e.Name,
+                data = Base64.Serialize(e.Data),
+                scope = e.Scope,
+                subject = e.Subject,
+                operationId = e.OperationId
+            })
+            .ToList();
+
+        HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Trigger, JsonConvert.SerializeObject(data, JsonSerializerSettings));
+    }
+
+    private void PopulateClientScripts()
+    {
+        if (!_clientScripts.Any())
+        {
+            return;
+        }
+
+        HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Scripts, JsonConvert.SerializeObject(_clientScripts, JsonSerializerSettings));
+
+        _clientScripts.Clear();
+    }
+
+    private bool IsComponentIdRendered(string componentId)
+    {
+        var renderedComponentIds = (string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds];
+        return renderedComponentIds.Contains(componentId);
+    }
+
+    private async Task TriggerMethod()
+    {
+        if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out var method)
+            || method is not string methodValue || string.IsNullOrWhiteSpace(methodValue))
+        {
+            return;
+        }
+
+        var methodInfos = GetType()
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+        var requestParameters = (IDictionary<string, object>)HttpContext.Items[HydroConsts.ContextItems.Parameters];
+
+        var methodInfo = methodInfos.FirstOrDefault(m =>
+            string.Equals(m.Name, methodValue, StringComparison.OrdinalIgnoreCase)
+            && m.GetParameters().Select(p => p.Name).SequenceEqual(requestParameters.Select(p => p.Key))
+        );
+
+        if (methodInfo == null)
+        {
+            return;
+        }
+
+        var methodParameters = methodInfo.GetParameters();
+        var methodAttributes = methodInfo.GetCustomAttributes();
+
+        if (requestParameters.Count != methodParameters.Length
+            || requestParameters.Any(rp => !methodParameters.Any(mp => rp.Key == mp.Name)))
+        {
+            throw new InvalidOperationException("Wrong action parameters");
+        }
+
+        if (methodAttributes.Any(a => a.GetType() == typeof(SkipOutputAttribute)))
+        {
+            _skipOutput = true;
+            HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.SkipOutput, "True");
+        }
+
+        var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
+            ? incomingOperationId.First()
+            : Guid.NewGuid().ToString("N");
+
+        HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
+
+        var orderedParameters = methodParameters
+            .Select(p =>
+            {
+                var requestParameter = requestParameters[p.Name!];
+
+                if (requestParameter == null)
+                {
+                    return null;
+                }
+
+                var sourceType = requestParameter.GetType();
+
+                if (p.ParameterType == sourceType)
+                {
+                    return requestParameter;
+                }
+
+                if (p.ParameterType.IsEnum)
+                {
+                    return Enum.ToObject(p.ParameterType, requestParameter);
+                }
+
+                return TypeDescriptor.GetConverter(p.ParameterType).ConvertFrom(requestParameter);
+            })
+            .ToArray();
+
+        if (typeof(Task).IsAssignableFrom(methodInfo.ReturnType))
+        {
+            await (Task)methodInfo.Invoke(this, orderedParameters)!;
+        }
+        else
+        {
+            methodInfo.Invoke(this, orderedParameters);
+        }
+    }
+
+    /// <summary>
+    /// Get the payload transferred from previous page's component
+    /// </summary>
+    /// <typeparam name="T">Payload type</typeparam>
+    /// <returns>Payload</returns>
+    public T GetPayload<T>() =>
+        HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.Payload, out var payloadString)
+            ? JsonConvert.DeserializeObject<T>(payloadString)
+            : default;
+
+    private async Task TriggerEvent()
+    {
+        if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.EventName, out var eventName)
+            || eventName is not string eventNameValue || string.IsNullOrWhiteSpace(eventNameValue))
+        {
+            return;
+        }
+
+        var eventSubject = (string)HttpContext.Items[HydroConsts.ContextItems.EventSubject];
+        var subscriptions = _subscriptions
+            .Where(s => s.EventName == eventNameValue && (s.SubjectRetriever == null || s.SubjectRetriever() == eventSubject))
+            .ToList();
+
+        foreach (var subscription in subscriptions)
+        {
+            var methodInfo = subscription.Action.Method;
+            var parameters = methodInfo.GetParameters();
+            var parameterType = parameters.First().ParameterType;
+            var model = Base64.Deserialize((string)HttpContext.Items[HydroConsts.ContextItems.EventData], parameterType);
+
+            var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
+                ? incomingOperationId.First()
+                : Guid.NewGuid().ToString("N");
+
+            HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
+
+            var isAsync = typeof(Task).IsAssignableFrom(methodInfo.ReturnType);
+
+            if (isAsync)
+            {
+                var method = InvokeActionAsyncMethod.MakeGenericMethod(parameterType);
+                await (Task)method.Invoke(null, new[] { subscription.Action, model })!;
+            }
+            else
+            {
+                var method = InvokeActionMethod.MakeGenericMethod(parameterType);
+                method.Invoke(null, new[] { subscription.Action, model });
+            }
+        }
+    }
+
+    private static void InvokeAction<T>(Delegate actionDelegate, T instance)
+    {
+        var action = actionDelegate as Action<T>;
+        action?.Invoke(instance);
+    }
+
+    private static Task InvokeActionAsync<T>(Delegate actionDelegate, T instance)
+    {
+        var action = actionDelegate as Func<T, Task>;
+        return action!.Invoke(instance);
+    }
+
+    private void PopulateBaseModel(IPersistentState persistentState)
+    {
+        if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.BaseModel, out var baseModel))
+        {
+            var unprotect = persistentState.Unprotect((string)baseModel);
+            JsonConvert.PopulateObject(unprotect, this);
+        }
+    }
+
+    private async Task PopulateRequestModel()
+    {
+        if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.RequestForm, out var requestForm))
+        {
+            await BindModel((IFormCollection)requestForm);
+        }
+    }
+
+    private string GetRootComponentId() =>
+        ((string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds]).First();
+
+    private string GetViewPath() =>
+        ViewPath ?? GetViewPath(GetType());
+
+    /// <summary>
+    /// Get the view path based on the type
+    /// </summary>
+    protected string GetViewPath(Type type)
+    {
+        var assemblyName = type.Assembly.GetName().Name;
+        return $"{type.FullName!.Replace(assemblyName!, "~").Replace(".", "/")}.cshtml";
+    }
+
+    /// Get the view path based on the view name
+    protected string GetViewPath(string viewName)
+    {
+        var type = GetType();
+        return GetViewPath(type).Replace($"{type.Name}.cshtml", $"{viewName}.cshtml");
+    }
+
+    /// <summary>
+    /// Override this property if you want to use custom view path for the component
+    /// </summary>
+    public virtual string ViewPath => null;
+
+    private async Task<HtmlDocument> GetComponentHtml()
+    {
+        using var stream = new MemoryStream();
+        await using var writer = new StreamWriter(stream);
+
+        var previousWriter = ViewComponentContext.ViewContext.Writer;
+        ViewComponentContext.ViewContext.Writer = writer;
+        ViewComponentContext.ViewContext.CheckBoxHiddenInputRenderMode = CheckBoxHiddenInputRenderMode.None;
+
+        var result = View(GetViewPath(), this);
+
+        await result.ExecuteAsync(ViewComponentContext);
+        await writer.FlushAsync();
+
+        stream.Position = 0;
+        var htmlDocument = new HtmlDocument();
+        htmlDocument.Load(stream);
+        ViewComponentContext.ViewContext.Writer = previousWriter;
+        return htmlDocument;
+    }
+
+    /// <summary>
+    /// Method invoked when the component has received parameters from its parent in
+    /// the render tree, and the incoming values have been assigned to properties.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing any asynchronous operation.</returns>
+    protected virtual Task OnParametersSetAsync()
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Method invoked when the component has received parameters from its parent in
+    /// the render tree, and the incoming values have been assigned to properties.	/// </summary>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    public virtual async Task SetParametersAsync(object parameters)
+    {
+        switch (parameters)
+        {
+        case null:
+        return;
+
+        case IDictionary<string, object> dictionary:
+        ApplyObjectFromDictionary(this, dictionary);
+        break;
+
+        default:
+        ApplyObject(this, parameters);
+        break;
+        }
+
+        await OnParametersSetAsync();
+    }
+
+    private void ApplyObject<T>(T target, object source)
+    {
+        if (source == null || target == null)
+        {
+            return;
+        }
+
+        var sourceType = source.GetType();
+        var targetType = target.GetType();
+
+        foreach (var sourceProperty in sourceType.GetProperties())
+        {
+            var targetProperty = targetType.GetProperty(sourceProperty.Name);
+
+            if (targetProperty == null || !targetProperty.CanWrite)
+            {
+                continue;
+            }
+
+            object sourceValue;
+
+            if (sourceProperty.PropertyType == targetProperty.PropertyType)
+            {
+                sourceValue = sourceProperty.GetValue(source);
+            }
+            else
+            {
+                try
+                {
+                    var json = JsonConvert.SerializeObject(sourceProperty.GetValue(source), JsonSerializerSettings);
+                    sourceValue = JsonConvert.DeserializeObject(json, targetProperty.PropertyType);
+                }
+                catch
+                {
+                    throw new InvalidCastException($"Type mismatch in {sourceProperty.Name} parameter.");
+                }
+            }
+
+            targetProperty.SetValue(target, sourceValue);
+        }
+    }
+
+    private void ApplyObjectFromDictionary<T>(T target, IDictionary<string, object> source)
+    {
+        if (source == null || target == null)
+        {
+            return;
+        }
+
+        var targetType = target.GetType();
+
+        foreach (var sourceProperty in source)
+        {
+            var targetProperty = targetType.GetProperty(sourceProperty.Key, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+
+            if (targetProperty == null || !targetProperty.CanWrite)
+            {
+                continue;
+            }
+
+            var value = sourceProperty.Value;
+
+            if (value != null && !targetProperty.PropertyType.IsInstanceOfType(value))
+            {
+                throw new InvalidCastException($"Type mismatch in {sourceProperty.Key} parameter.");
+            }
+
+            targetProperty.SetValue(target, value);
+        }
+    }
+
+    /// <summary>
+    /// Validate the model state
+    /// </summary>
+    /// <returns>True if the state is valid</returns>
+    public bool Validate()
+    {
+        IsModelTouched = true;
+        return ValidateTouched();
+    }
+
+    private bool ValidateTouched()
+    {
+        ModelState.Clear();
+
+        var context = new ValidationContext(this, serviceProvider: HttpContext.RequestServices, items: null);
+        var validationResults = new List<ValidationResult>();
+        Validator.TryValidateObject(this, context, validationResults, true);
+        var extractValidationResults = ExtractValidationResults(validationResults);
+
+        foreach (var validationResult in extractValidationResults)
+        {
+            foreach (var memberName in validationResult.MemberNames)
+            {
+                if (IsModelTouched || TouchedProperties.Contains(memberName) || TouchedProperties.Any(p => p.StartsWith($"{memberName}.")))
+                {
+                    ModelState.AddModelError(memberName, validationResult.ErrorMessage!);
+                }
+            }
+        }
+
+        IsValid = ModelState.IsValid;
+
+        return IsValid;
+    }
+
+    private static IEnumerable<ValidationResult> ExtractValidationResults(IEnumerable<ValidationResult> validationResults)
+    {
+        foreach (var result in validationResults)
+        {
+            yield return result;
+
+            if (result is ICompositeValidationResult compositeResult)
+            {
+                foreach (var innerResult in compositeResult.Results)
+                {
+                    yield return innerResult;
+                }
+            }
+        }
+    }
+
+    private async Task<bool> AuthorizeAsync()
+    {
+        var type = GetType();
+
+        if (!ComponentAuthorizationAttributes.ContainsKey(type))
+        {
+            ComponentAuthorizationAttributes.TryAdd(type, type.GetCustomAttributes(true)
+                .Where(attr => attr is IHydroAuthorizationFilter)
+                .Cast<IHydroAuthorizationFilter>()
+                .ToArray());
+        }
+
+        foreach (var authorizationFilter in ComponentAuthorizationAttributes[type])
+        {
+            if (!await authorizationFilter.AuthorizeAsync(HttpContext, this))
+            {
+                if (HttpContext.IsHydro(excludeBoosted: true))
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+                }
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Queue JS to be executed on client side upon rendering component
+    /// </summary>
+    /// <param name="script"></param>
+    public void ExecuteJs(string script)
+    {
+        _clientScripts.Add(script);
+    }
+
+    private static string Hash(string input) =>
+        $"W{Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(input)))}";
+
+
+    /// <summary>
+    /// Binds model with the request Form if any and updates ModelState. WIth optional preValidate you can transform/check model values before they go to validation and even add your own validation errors. Return value is equal to  ModelState.IsValid.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="model"></param>
+    /// <param name="preValidate"></param>
+    /// <returns></returns>
+    public virtual async Task<bool> BindFormAndValidateAsync<T>(T model, Action<T, ModelStateDictionary> preValidate = null)
+    {
+        ModelState.Clear();
+        IsModelTouched = true;
+
+        var factory = HttpContext.RequestServices.GetRequiredService<IModelBinderFactory>();
+        var metadataProvider = HttpContext.RequestServices.GetRequiredService<IModelMetadataProvider>();
+        var modelMetadata = metadataProvider.GetMetadataForType(typeof(T));
+        var modelBinder = factory.CreateBinder(new ModelBinderFactoryContext
+        {
+            BindingInfo = new BindingInfo { BindingSource = BindingSource.Form },
+            Metadata = modelMetadata,
+            CacheToken = modelMetadata
+        });
+
+        var bindingInfo = new BindingInfo
+        {
+            BindingSource = BindingSource.Form
+        };
+
+        var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
+            ViewContext,
+            new CompositeValueProvider { new FormValueProvider(BindingSource.Form, HttpContext.Request.Form, CultureInfo.CurrentCulture) },
+            modelMetadata,
+            bindingInfo: bindingInfo,
+            modelName: typeof(T).Name);
+
+        modelBindingContext.Model = model;
+
+        await modelBinder.BindModelAsync(modelBindingContext);
+
+        preValidate?.Invoke(model, modelBindingContext.ModelState);
+
+        if (modelBindingContext.Result.IsModelSet)
+        {
+            var validationResults = new HashSet<ValidationResult>();
+            var isValid = Validator.TryValidateObject(model, new ValidationContext(model, HttpContext.RequestServices, null), validationResults, true);
+            if (!isValid)
+            {
+                foreach (var validationResult in validationResults)
+                {
+                    foreach (var memberName in validationResult.MemberNames)
+                    {
+                        modelBindingContext.ModelState.AddModelError(memberName, validationResult.ErrorMessage);
+                    }
+                }
+            }
+        }
+
+        if (!modelBindingContext.ModelState.IsValid)
+        {
+            foreach (var key in modelBindingContext.ModelState.Keys)
+            {
+                var values = modelBindingContext.ModelState[key];
+                if (values != null)
+                    foreach (var error in values.Errors)
+                    {
+                        ModelState.AddModelError(key, error.ErrorMessage);
+                    }
+            }
+        }
+
+        return ModelState.IsValid;
+    }
 }

--- a/src/HydroComponent.cs
+++ b/src/HydroComponent.cs
@@ -26,1185 +26,1185 @@ namespace Hydro;
 public abstract class HydroComponent : ViewComponent
 {
 
-    private string _componentId;
-    private bool _skipOutput;
-
-    private readonly ConcurrentDictionary<CacheKey, object> _requestCache = new();
-    private static readonly ConcurrentDictionary<CacheKey, object> PersistentCache = new();
-
-    private static readonly ConcurrentDictionary<Type, List<HydroPoll>> Polls = new();
-
-    private readonly List<string> _clientScripts = new();
-    private readonly List<HydroComponentEvent> _dispatchEvents = new();
-    private readonly HashSet<HydroEventSubscription> _subscriptions = new();
-
-    private static readonly MethodInfo InvokeActionMethod = typeof(HydroComponent).GetMethod(nameof(InvokeAction), BindingFlags.Static | BindingFlags.NonPublic);
-    private static readonly MethodInfo InvokeActionAsyncMethod = typeof(HydroComponent).GetMethod(nameof(InvokeActionAsync), BindingFlags.Static | BindingFlags.NonPublic);
-
-    private static readonly JsonSerializerSettings JsonSerializerSettings = new()
-    {
-        Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-    };
-
-    private static readonly ConcurrentDictionary<Type, IHydroAuthorizationFilter[]> ComponentAuthorizationAttributes = new();
-    private HydroOptions _options;
-
-    /// <summary>
-    /// Provides indication if ModelState is valid
-    /// </summary>
-    protected bool IsValid { get; private set; }
-
-    /// <summary>
-    /// Provides component's key value
-    /// </summary>
-    protected string Key { get; private set; }
-
-    /// <summary>
-    /// Provides list of already accessed component's properties  
-    /// </summary>
-    public HashSet<string> TouchedProperties { get; set; } = new();
-
-    /// <summary>
-    /// Determines if the whole model was accessed already
-    /// </summary>
-    public bool IsModelTouched { get; set; }
-
-    /// <summary>
-    /// Determines if the current execution is related to the component mounting
-    /// </summary>
-    [Transient]
-    public bool IsMount { get; set; }
-
-    /// <summary>
-    /// Unique component identifier
-    /// </summary>
-    public string ComponentId => _componentId;
-
-    /// <summary />
-    public HydroComponent()
-    {
-        Subscribe<HydroBind>(data => SetPropertyValue(data.Name, data.Value));
-
-        ConfigurePolls();
-    }
-
-    private void ConfigurePolls()
-    {
-        var componentType = GetType();
-
-        if (Polls.ContainsKey(componentType))
-        {
-            return;
-        }
-
-        var methods = componentType
-            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .Where(m => m.DeclaringType != typeof(HydroComponent))
-            .Select(m => (Method: m, Attribute: m.GetCustomAttribute<PollAttribute>()))
-            .Where(m => m.Attribute != null)
-            .Select(m => (m.Method, m.Attribute, ParametersCount: m.Method.GetParameters().Length))
-            .ToList();
-
-        if (methods.Any(p => p.Method.GetBaseDefinition() != p.Method))
-        {
-            throw new InvalidOperationException("Poll can be defined only on custom actions");
-        }
-
-        if (methods.Any(p => p.ParametersCount != 0))
-        {
-            throw new InvalidOperationException("Poll can be defined only on actions without parameters");
-        }
-
-        if (methods.Any(p => p.Attribute.Interval <= 0))
-        {
-            throw new InvalidOperationException("Polling's interval is invalid");
-        }
-
-        var polls = methods
-            .Select(p => new HydroPoll(p.Method.Name, TimeSpan.FromMilliseconds(p.Attribute.Interval)))
-            .ToList();
-
-        Polls.TryAdd(componentType, polls);
-    }
-
-    /// <summary>
-    /// Implementation of ViewComponent's InvokeAsync method
-    /// </summary>
-    /// <param name="parameters">Parameters</param>
-    /// <param name="key">Key</param>
-    public async Task<IHtmlContent> InvokeAsync(object parameters = null, string key = null)
-    {
-        var componentHtml = string.Empty;
-        if (ShouldRender())
-        {
-            await SetParametersAsync(parameters);
-
-            ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = null;
-            Key = key;
-
-            var persistentState = HttpContext.RequestServices.GetService<IPersistentState>();
-
-            _options = HttpContext.RequestServices.GetService<HydroOptions>();
-
-            if (persistentState == null || _options == null)
-            {
-                throw new ApplicationException("Hydro have not been initialized");
-            }
-
-            var firstRender = !IsMount;
-
-            try
-            {
-                //we need to for async threads called upon Dispatch, otherwise could just crash silently
-                componentHtml = HttpContext.IsHydro(excludeBoosted: true)
-                    ? await RenderOnlineComponent(persistentState)
-                    : await RenderStaticComponent(persistentState);
-            }
-            catch (Exception e)
-            {
-                HandleError(e);
-            }
-
-            await OnAfterRenderAsync(firstRender);
-        }
-
-        return new HtmlString(componentHtml);
-    }
-
-    public virtual void HandleError(Exception e)
-    {
-        var message = $"{e.Message} {e.StackTrace}";
-        Debug.WriteLine(message);
-        Dispatch(new UnhandledHydroError(message, e), Scope.Global);
-    }
-
-    /// <summary>
-    /// Method invoked after each time the component has been rendered.
-    /// </summary>
-    /// <param name="firstRender">
-    /// Set to <c>true</c> if this is the first time it was rendered
-    /// </param>
-    protected virtual Task OnAfterRenderAsync(bool firstRender)
-        => Task.CompletedTask;
-
-    /// <summary>
-    /// Subscribes to a Hydro event
-    /// </summary>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Subscribe<TEvent>(Func<string> subject = null) =>
-        _subscriptions.Add(new HydroEventSubscription
-        {
-            EventName = GetFullTypeName(typeof(TEvent)),
-            SubjectRetriever = subject,
-            Action = (TEvent _) => { }
-        });
-
-    /// <summary>
-    /// Subscribes to a Hydro event
-    /// </summary>
-    /// <param name="action">Action to execute when event occurs</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Subscribe<TEvent>(Action<TEvent> action) =>
-        _subscriptions.Add(new HydroEventSubscription
-        {
-            EventName = GetFullTypeName(typeof(TEvent)),
-            Action = action
-        });
-
-    /// <summary>
-    /// Subscribes to a Hydro event
-    /// </summary>
-    /// <param name="subject">Subject</param>
-    /// <param name="action">Action to execute when event occurs</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Subscribe<TEvent>(Func<string> subject, Action<TEvent> action) =>
-        _subscriptions.Add(new HydroEventSubscription
-        {
-            EventName = GetFullTypeName(typeof(TEvent)),
-            SubjectRetriever = subject,
-            Action = action
-        });
-
-    private static string GetFullTypeName(Type type) =>
-        type.DeclaringType != null
-            ? type.DeclaringType.Name + "+" + type.Name
-            : type.Name;
-
-    /// <summary>
-    /// Subscribes to a Hydro event
-    /// </summary>
-    /// <param name="action">Action to execute when event occurs</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Subscribe<TEvent>(Func<TEvent, Task> action) =>
-        _subscriptions.Add(new HydroEventSubscription
-        {
-            EventName = GetFullTypeName(typeof(TEvent)),
-            Action = action
-        });
-
-    /// <summary>
-    /// Subscribes to a Hydro event
-    /// </summary>
-    /// <param name="subject">Subject</param>
-    /// <param name="action">Action to execute when event occurs</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Subscribe<TEvent>(Func<string> subject, Func<TEvent, Task> action) =>
-        _subscriptions.Add(new HydroEventSubscription
-        {
-            EventName = GetFullTypeName(typeof(TEvent)),
-            Action = action,
-            SubjectRetriever = subject
-        });
-
-    /// <summary>
-    /// Unsubscribe from a Hydro event
-    /// </summary>
-    /// <typeparam name="TEvent"></typeparam>
-    public void Unsubscribe<TEvent>()
-    {
-        var found = _subscriptions.RemoveWhere(x => x.EventName == typeof(TEvent).Name);
-    }
-
-    /// <summary>
-    /// Triggers a Hydro event
-    /// </summary>
-    /// <param name="data">Data to pass</param>
-    /// <param name="scope">Scope of the event</param>
-    /// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Dispatch<TEvent>(TEvent data, Scope scope = Scope.Parent, bool asynchronous = false) =>
-        Dispatch(GetFullTypeName(typeof(TEvent)), data, scope, asynchronous);
-
-    /// <summary>
-    /// Triggers a Hydro event
-    /// </summary>
-    /// <param name="name">Name of the event</param>
-    /// <param name="data">Data to pass</param>
-    /// <param name="scope">Scope of the event</param>
-    /// <param name="subject">Subject</param>
-    /// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void Dispatch<TEvent>(string name, TEvent data, Scope scope = Scope.Parent, bool asynchronous = false, string subject = null)
-    {
-        var operationId = !asynchronous && HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
-            ? incomingOperationId.First()
-            : Guid.NewGuid().ToString("N");
-
-        _dispatchEvents.Add(new HydroComponentEvent
-        {
-            Name = name,
-            Data = data,
-            Scope = scope.ToString().ToLower(),
-            Subject = subject,
-            OperationId = operationId
-        });
-    }
-
-    /// <summary>
-    /// Triggers a Hydro event in a global scope
-    /// </summary>
-    /// <param name="data">Data to pass</param>
-    /// <param name="subject">Subject</param>
-    /// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
-    /// <typeparam name="TEvent">Event type</typeparam>
-    public void DispatchGlobal<TEvent>(TEvent data, string subject = null, bool asynchronous = false) =>
-        Dispatch(GetFullTypeName(typeof(TEvent)), data, Scope.Global, asynchronous, subject);
-
-    /// <summary>
-    /// Provides actions that can be executed on client side
-    /// </summary>
-    public HydroClientActions Client { get; } = new();
-
-    /// <summary>
-    /// Triggered once the component is mounted
-    /// </summary>
-    public virtual Task MountAsync()
-    {
-        Mount();
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Triggered once the component is mounted
-    /// </summary>
-    public virtual void Mount()
-    {
-    }
-
-    /// <summary>
-    /// Triggered before each render
-    /// </summary>
-    public virtual Task RenderAsync()
-    {
-        Render();
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Returns a flag to indicate whether the component should render.
-    /// </summary>
-    /// <returns></returns>
-    protected virtual bool ShouldRender()
-        => true;
-
-    /// <summary>
-    /// Triggered before each render
-    /// </summary>
-    public virtual void Render()
-    {
-    }
-
-    /// <summary>
-    /// Perform a redirect with page reload
-    /// </summary>
-    /// <param name="url">Destination URL</param>
-    public void Redirect(string url) =>
-        HttpContext.Response.HydroRedirect(url);
-
-    /// <summary>
-    /// Perform a redirect without page reload
-    /// </summary>
-    /// <param name="url">Destination URL</param>
-    /// <param name="payload">Payload for the destination components</param>
-    public void Location(string url, object payload = null) =>
-        HttpContext.Response.HydroLocation(url, payload);
-
-    /// <summary>
-    /// Perform a redirect without page reload, but intead of replacing the whole body replaces the specified element. Example "#renderBody" or "renderBody" etc..
-    /// </summary>
-    /// <param name="url"></param>
-    /// <param name="target"></param>
-    /// <param name="payload"></param>
-    public void Location(string url, string target, object payload = null) =>
-        HttpContext.Response.HydroLocation(url, target, payload);
-
-    /// <summary>
-    /// Cache value
-    /// </summary>
-    /// <param name="func">Value producer</param>
-    /// <param name="lifetime">Lifetime of the cached value</param>
-    /// <typeparam name="T">Type of the value</typeparam>
-    /// <returns>Produced value</returns>
-    protected Cache<T> Cache<T>(Func<T> func, CacheLifetime lifetime = CacheLifetime.Request)
-    {
-        var cache = lifetime == CacheLifetime.Request ? _requestCache : PersistentCache;
-
-        var cacheKey = new CacheKey(_componentId, func);
-        if (cache.TryGetValue(cacheKey, out var dic))
-        {
-            var value = (Cache<T>)dic;
-
-            if (!value.IsSet)
-            {
-                cache.Remove(cacheKey, out _);
-            }
-            else
-            {
-                return value;
-            }
-        }
-
-        var cacheValue = new Cache<T>(func);
-        cache.TryAdd(cacheKey, cacheValue);
-        return cacheValue;
-    }
-
-    private async Task<string> RenderOnlineComponent(IPersistentState persistentState) =>
-        DetermineRootComponent()
-            ? await RenderOnlineRootComponent(persistentState)
-            : await RenderOnlineNestedComponent(persistentState);
-
-    private bool DetermineRootComponent()
-    {
-        if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.IsRootRendered, out _))
-        {
-            HttpContext.Items.TryAdd(HydroConsts.ContextItems.IsRootRendered, true);
-            return true;
-        }
-
-        return false;
-    }
-
-    private async Task<string> RenderOnlineRootComponent(IPersistentState persistentState)
-    {
-        var componentId = GetRootComponentId();
-        _componentId = componentId;
-
-        PopulateBaseModel(persistentState);
-        await PopulateRequestModel();
-        if (!await AuthorizeAsync())
-        {
-            return string.Empty;
-        }
-
-        await TriggerEvent();
-
-        ValidateTouched();
-
-        await TriggerMethod();
-
-        if (!_skipOutput)
-        {
-            await RenderAsync();
-        }
-
-        PopulateDispatchers();
-
-        PopulateClientScripts();
-
-        return !_skipOutput
-            ? await GenerateComponentHtml(componentId, persistentState, false)
-            : string.Empty;
-    }
-
-    private async Task<string> RenderOnlineNestedComponent(IPersistentState persistentState)
-    {
-        var componentId = GenerateComponentId(Key);
-        _componentId = componentId;
-
-        if (IsComponentIdRendered(componentId))
-        {
-            return GetComponentPlaceholderTemplate(componentId);
-        }
-
-        if (!await AuthorizeAsync())
-        {
-            return string.Empty;
-        }
-
-        IsMount = true;
-        await MountAsync();
-        await RenderAsync();
-        return await GenerateComponentHtml(componentId, persistentState, true);
-    }
-
-    private static string GetComponentPlaceholderTemplate(string componentId) =>
-        $"<div id=\"{componentId}\" key=\"{componentId}\" hydro hydro-placeholder></div>";
-
-    private async Task<string> RenderStaticComponent(IPersistentState persistentState)
-    {
-        var componentId = GenerateComponentId(Key);
-        _componentId = componentId;
-
-        if (!await AuthorizeAsync())
-        {
-            return string.Empty;
-        }
-
-        IsMount = true;
-        await MountAsync();
-        await RenderAsync();
-        return await GenerateComponentHtml(componentId, persistentState, true);
-    }
-
-    private string GenerateComponentId(string key)
-    {
-        var parentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
-        var mainId = parentComponentId ?? $"{Guid.NewGuid():N}";
-        var typeName = GetType().Name;
-
-
-        var generateComponentId = Hash($"{mainId}-{typeName}-{key}");
-        return generateComponentId;
-    }
-
-    private async Task<string> GenerateComponentHtml(string componentId, IPersistentState persistentState, bool isStatic)
-    {
-        var previousParentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
-        HttpContext.Items[HydroConsts.Component.ParentComponentId] = componentId;
-
-        var componentHtmlDocument = await GetComponentHtml();
-
-        HttpContext.Items[HydroConsts.Component.ParentComponentId] = previousParentComponentId;
-
-        var root = componentHtmlDocument.DocumentNode;
-
-        if (root.ChildNodes.Count(n => n.NodeType == HtmlNodeType.Element) != 1)
-        {
-            throw new InvalidOperationException("The wire component must have only one root element.");
-        }
-
-        var rootElement = root.ChildNodes.First(n => n.NodeType == HtmlNodeType.Element);
-
-        rootElement.SetAttributeValue("id", componentId);
-        rootElement.SetAttributeValue("key", componentId);
-        rootElement.SetAttributeValue("hydro-name", GetType().Name);
-        rootElement.SetAttributeValue("x-data", "hydro");
-        var hydroAttribute = rootElement.SetAttributeValue("hydro", null);
-        hydroAttribute.QuoteType = AttributeValueQuote.WithoutValue;
-
-        if (Polls.TryGetValue(GetType(), out var polls))
-        {
-            for (var i = 0; i < polls.Count; i++)
-            {
-                rootElement.AppendChild(GetPollScript(componentHtmlDocument, polls[i], i));
-            }
-        }
-
-        rootElement.AppendChild(GetModelScript(componentHtmlDocument, componentId, persistentState));
-
-        foreach (var subscription in _subscriptions)
-        {
-            rootElement.AppendChild(GetEventSubscriptionScript(componentHtmlDocument, subscription));
-        }
-
-        if (isStatic)
-        {
-            foreach (var script in _clientScripts)
-            {
-                rootElement.AppendChild(GetStaticScript(componentHtmlDocument, script));
-            }
-        }
-
-        return rootElement.OuterHtml;
-    }
-
-    private async Task BindModel(IFormCollection formCollection)
-    {
-        if (!IsModelTouched)
-        {
-            if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out _))
-            {
-                IsModelTouched = true;
-            }
-            else
-            {
-                foreach (var item in formCollection)
-                {
-                    TouchedProperties.Add(item.Key);
-                }
-            }
-        }
-
-        foreach (var pair in formCollection)
-        {
-            var setter = PropertyInjector.GetPropertySetter(this, pair.Key, pair.Value);
-            var propertyPath = PropertyPath.ExtractPropertyPath(pair.Key);
-
-            if (setter != null)
-            {
-                var value = setter.Value.Value == null
-                    ? null
-                    : _options.ValueMappersDictionary.TryGetValue(setter.Value.Value.GetType(), out var mapper)
-                        ? await mapper.Map(setter.Value.Value)
-                        : setter.Value.Value;
-
-                setter.Value.Setter(value);
-                await BindAsync(propertyPath, value);
-            }
-            else
-            {
-                await BindAsync(propertyPath, null);
-            }
-        }
-
-        foreach (var file in formCollection.Files)
-        {
-            var setter = PropertyInjector.GetPropertySetter(this, file.Name, file);
-            var propertyPath = PropertyPath.ExtractPropertyPath(file.Name);
-
-            if (setter != null)
-            {
-                setter.Value.Setter(file);
-                await BindAsync(propertyPath, file);
-            }
-            else
-            {
-                await BindAsync(propertyPath, null);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Applies value to a component
-    /// </summary>
-    /// <param name="path">Path to the value</param>
-    /// <param name="value">Value</param>
-    public async Task SetPropertyValue(string path, object value)
-    {
-        PropertyInjector.SetPropertyValue(this, path, value);
-        TouchedProperties.Add(path);
-        await BindAsync(PropertyPath.ExtractPropertyPath(path), value);
-    }
-
-    /// <summary>
-    /// Triggered when a property is updated from the client
-    /// </summary>
-    /// <param name="property">Property path</param>
-    /// <param name="value">New value</param>
-    public virtual void Bind(PropertyPath property, object value)
-    {
-    }
-
-    /// <summary>
-    /// Triggered when a property is updated from the client
-    /// </summary>
-    /// <param name="property">Property path</param>
-    /// <param name="value">New value</param>
-    public virtual Task BindAsync(PropertyPath property, object value)
-    {
-        Bind(property, value);
-        return Task.CompletedTask;
-    }
-
-    private HtmlNode GetModelScript(HtmlDocument document, string id, IPersistentState persistentState)
-    {
-        var scriptNode = document.CreateElement("script");
-        scriptNode.SetAttributeValue("type", "text/hydro");
-        scriptNode.SetAttributeValue("data-id", id);
-        var serializeDeclaredProperties = PropertyInjector.SerializeDeclaredProperties(GetType(), this);
-        var model = persistentState.Protect(serializeDeclaredProperties);
-        scriptNode.AppendChild(document.CreateTextNode(model));
-        return scriptNode;
-    }
-
-    private HtmlNode GetEventSubscriptionScript(HtmlDocument document, HydroEventSubscription subscription)
-    {
-        var eventData = new
-        {
-            name = subscription.EventName,
-            subject = subscription.SubjectRetriever?.Invoke(),
-            path = $"/hydro/{GetType().Name}/event".ToLower()
-        };
-
-        var scriptNode = document.CreateElement("script");
-        scriptNode.SetAttributeValue("key", $"R{Guid.NewGuid():N}");
-        scriptNode.SetAttributeValue("type", "text/hydro");
-        scriptNode.SetAttributeValue("hydro-event", "true");
-        scriptNode.SetAttributeValue("x-data", "");
-        scriptNode.SetAttributeValue("x-on-hydro-event", JsonConvert.SerializeObject(eventData, JsonSerializerSettings));
-        return scriptNode;
-    }
-
-    private HtmlNode GetPollScript(HtmlDocument document, HydroPoll poll, int index)
-    {
-        var scriptNode = document.CreateElement("script");
-        scriptNode.SetAttributeValue($"x-hydro-polling.{poll.Interval.TotalMilliseconds}ms._{index}", poll.Action);
-        scriptNode.SetAttributeValue("type", "text/hydro");
-        return scriptNode;
-    }
-
-    private HtmlNode GetStaticScript(HtmlDocument document, string script)
-    {
-        var scriptNode = document.CreateElement("script");
-        scriptNode.SetAttributeValue("hydro-js", "true");
-        scriptNode.SetAttributeValue("type", "text/hydro");
-        scriptNode.InnerHtml = script;
-        return scriptNode;
-    }
-
-    private void PopulateDispatchers()
-    {
-        if (!_dispatchEvents.Any())
-        {
-            return;
-        }
-
-        var data = _dispatchEvents
-            .Select(e => new
-            {
-                name = e.Name,
-                data = Base64.Serialize(e.Data),
-                scope = e.Scope,
-                subject = e.Subject,
-                operationId = e.OperationId
-            })
-            .ToList();
-
-        HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Trigger, JsonConvert.SerializeObject(data, JsonSerializerSettings));
-    }
-
-    private void PopulateClientScripts()
-    {
-        if (!_clientScripts.Any())
-        {
-            return;
-        }
-
-        HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Scripts, JsonConvert.SerializeObject(_clientScripts, JsonSerializerSettings));
-
-        _clientScripts.Clear();
-    }
-
-    private bool IsComponentIdRendered(string componentId)
-    {
-        var renderedComponentIds = (string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds];
-        return renderedComponentIds.Contains(componentId);
-    }
-
-    private async Task TriggerMethod()
-    {
-        if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out var method)
-            || method is not string methodValue || string.IsNullOrWhiteSpace(methodValue))
-        {
-            return;
-        }
-
-        var methodInfos = GetType()
-            .GetMethods(BindingFlags.Public | BindingFlags.Instance);
-
-        var requestParameters = (IDictionary<string, object>)HttpContext.Items[HydroConsts.ContextItems.Parameters];
-
-        var methodInfo = methodInfos.FirstOrDefault(m =>
-            string.Equals(m.Name, methodValue, StringComparison.OrdinalIgnoreCase)
-            && m.GetParameters().Select(p => p.Name).SequenceEqual(requestParameters.Select(p => p.Key))
-        );
-
-        if (methodInfo == null)
-        {
-            return;
-        }
-
-        var methodParameters = methodInfo.GetParameters();
-        var methodAttributes = methodInfo.GetCustomAttributes();
-
-        if (requestParameters.Count != methodParameters.Length
-            || requestParameters.Any(rp => !methodParameters.Any(mp => rp.Key == mp.Name)))
-        {
-            throw new InvalidOperationException("Wrong action parameters");
-        }
-
-        if (methodAttributes.Any(a => a.GetType() == typeof(SkipOutputAttribute)))
-        {
-            _skipOutput = true;
-            HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.SkipOutput, "True");
-        }
-
-        var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
-            ? incomingOperationId.First()
-            : Guid.NewGuid().ToString("N");
-
-        HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
-
-        var orderedParameters = methodParameters
-            .Select(p =>
-            {
-                var requestParameter = requestParameters[p.Name!];
-
-                if (requestParameter == null)
-                {
-                    return null;
-                }
-
-                var sourceType = requestParameter.GetType();
-
-                if (p.ParameterType == sourceType)
-                {
-                    return requestParameter;
-                }
-
-                if (p.ParameterType.IsEnum)
-                {
-                    return Enum.ToObject(p.ParameterType, requestParameter);
-                }
-
-                return TypeDescriptor.GetConverter(p.ParameterType).ConvertFrom(requestParameter);
-            })
-            .ToArray();
-
-        if (typeof(Task).IsAssignableFrom(methodInfo.ReturnType))
-        {
-            await (Task)methodInfo.Invoke(this, orderedParameters)!;
-        }
-        else
-        {
-            methodInfo.Invoke(this, orderedParameters);
-        }
-    }
-
-    /// <summary>
-    /// Get the payload transferred from previous page's component
-    /// </summary>
-    /// <typeparam name="T">Payload type</typeparam>
-    /// <returns>Payload</returns>
-    public T GetPayload<T>() =>
-        HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.Payload, out var payloadString)
-            ? JsonConvert.DeserializeObject<T>(payloadString)
-            : default;
-
-    private async Task TriggerEvent()
-    {
-        if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.EventName, out var eventName)
-            || eventName is not string eventNameValue || string.IsNullOrWhiteSpace(eventNameValue))
-        {
-            return;
-        }
-
-        var eventSubject = (string)HttpContext.Items[HydroConsts.ContextItems.EventSubject];
-        var subscriptions = _subscriptions
-            .Where(s => s.EventName == eventNameValue && (s.SubjectRetriever == null || s.SubjectRetriever() == eventSubject))
-            .ToList();
-
-        foreach (var subscription in subscriptions)
-        {
-            var methodInfo = subscription.Action.Method;
-            var parameters = methodInfo.GetParameters();
-            var parameterType = parameters.First().ParameterType;
-            var model = Base64.Deserialize((string)HttpContext.Items[HydroConsts.ContextItems.EventData], parameterType);
-
-            var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
-                ? incomingOperationId.First()
-                : Guid.NewGuid().ToString("N");
-
-            HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
-
-            var isAsync = typeof(Task).IsAssignableFrom(methodInfo.ReturnType);
-
-            if (isAsync)
-            {
-                var method = InvokeActionAsyncMethod.MakeGenericMethod(parameterType);
-                await (Task)method.Invoke(null, new[] { subscription.Action, model })!;
-            }
-            else
-            {
-                var method = InvokeActionMethod.MakeGenericMethod(parameterType);
-                method.Invoke(null, new[] { subscription.Action, model });
-            }
-        }
-    }
-
-    private static void InvokeAction<T>(Delegate actionDelegate, T instance)
-    {
-        var action = actionDelegate as Action<T>;
-        action?.Invoke(instance);
-    }
-
-    private static Task InvokeActionAsync<T>(Delegate actionDelegate, T instance)
-    {
-        var action = actionDelegate as Func<T, Task>;
-        return action!.Invoke(instance);
-    }
-
-    private void PopulateBaseModel(IPersistentState persistentState)
-    {
-        if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.BaseModel, out var baseModel))
-        {
-            var unprotect = persistentState.Unprotect((string)baseModel);
-            JsonConvert.PopulateObject(unprotect, this);
-        }
-    }
-
-    private async Task PopulateRequestModel()
-    {
-        if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.RequestForm, out var requestForm))
-        {
-            await BindModel((IFormCollection)requestForm);
-        }
-    }
-
-    private string GetRootComponentId() =>
-        ((string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds]).First();
-
-    private string GetViewPath() =>
-        ViewPath ?? GetViewPath(GetType());
-
-    /// <summary>
-    /// Get the view path based on the type
-    /// </summary>
-    protected string GetViewPath(Type type)
-    {
-        var assemblyName = type.Assembly.GetName().Name;
-        return $"{type.FullName!.Replace(assemblyName!, "~").Replace(".", "/")}.cshtml";
-    }
-
-    /// Get the view path based on the view name
-    protected string GetViewPath(string viewName)
-    {
-        var type = GetType();
-        return GetViewPath(type).Replace($"{type.Name}.cshtml", $"{viewName}.cshtml");
-    }
-
-    /// <summary>
-    /// Override this property if you want to use custom view path for the component
-    /// </summary>
-    public virtual string ViewPath => null;
-
-    private async Task<HtmlDocument> GetComponentHtml()
-    {
-        using var stream = new MemoryStream();
-        await using var writer = new StreamWriter(stream);
-
-        var previousWriter = ViewComponentContext.ViewContext.Writer;
-        ViewComponentContext.ViewContext.Writer = writer;
-        ViewComponentContext.ViewContext.CheckBoxHiddenInputRenderMode = CheckBoxHiddenInputRenderMode.None;
-
-        var result = View(GetViewPath(), this);
-
-        await result.ExecuteAsync(ViewComponentContext);
-        await writer.FlushAsync();
-
-        stream.Position = 0;
-        var htmlDocument = new HtmlDocument();
-        htmlDocument.Load(stream);
-        ViewComponentContext.ViewContext.Writer = previousWriter;
-        return htmlDocument;
-    }
-
-    /// <summary>
-    /// Method invoked when the component has received parameters from its parent in
-    /// the render tree, and the incoming values have been assigned to properties.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> representing any asynchronous operation.</returns>
-    protected virtual Task OnParametersSetAsync()
-        => Task.CompletedTask;
-
-    /// <summary>
-    /// Method invoked when the component has received parameters from its parent in
-    /// the render tree, and the incoming values have been assigned to properties.	/// </summary>
-    /// <param name="parameters"></param>
-    /// <returns></returns>
-    public virtual async Task SetParametersAsync(object parameters)
-    {
-        switch (parameters)
-        {
-        case null:
-        return;
-
-        case IDictionary<string, object> dictionary:
-        ApplyObjectFromDictionary(this, dictionary);
-        break;
-
-        default:
-        ApplyObject(this, parameters);
-        break;
-        }
-
-        await OnParametersSetAsync();
-    }
-
-    private void ApplyObject<T>(T target, object source)
-    {
-        if (source == null || target == null)
-        {
-            return;
-        }
-
-        var sourceType = source.GetType();
-        var targetType = target.GetType();
-
-        foreach (var sourceProperty in sourceType.GetProperties())
-        {
-            var targetProperty = targetType.GetProperty(sourceProperty.Name);
-
-            if (targetProperty == null || !targetProperty.CanWrite)
-            {
-                continue;
-            }
-
-            object sourceValue;
-
-            if (sourceProperty.PropertyType == targetProperty.PropertyType)
-            {
-                sourceValue = sourceProperty.GetValue(source);
-            }
-            else
-            {
-                try
-                {
-                    var json = JsonConvert.SerializeObject(sourceProperty.GetValue(source), JsonSerializerSettings);
-                    sourceValue = JsonConvert.DeserializeObject(json, targetProperty.PropertyType);
-                }
-                catch
-                {
-                    throw new InvalidCastException($"Type mismatch in {sourceProperty.Name} parameter.");
-                }
-            }
-
-            targetProperty.SetValue(target, sourceValue);
-        }
-    }
-
-    private void ApplyObjectFromDictionary<T>(T target, IDictionary<string, object> source)
-    {
-        if (source == null || target == null)
-        {
-            return;
-        }
-
-        var targetType = target.GetType();
-
-        foreach (var sourceProperty in source)
-        {
-            var targetProperty = targetType.GetProperty(sourceProperty.Key, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-
-            if (targetProperty == null || !targetProperty.CanWrite)
-            {
-                continue;
-            }
-
-            var value = sourceProperty.Value;
-
-            if (value != null && !targetProperty.PropertyType.IsInstanceOfType(value))
-            {
-                throw new InvalidCastException($"Type mismatch in {sourceProperty.Key} parameter.");
-            }
-
-            targetProperty.SetValue(target, value);
-        }
-    }
-
-    /// <summary>
-    /// Validate the model state
-    /// </summary>
-    /// <returns>True if the state is valid</returns>
-    public bool Validate()
-    {
-        IsModelTouched = true;
-        return ValidateTouched();
-    }
-
-    private bool ValidateTouched()
-    {
-        ModelState.Clear();
-
-        var context = new ValidationContext(this, serviceProvider: HttpContext.RequestServices, items: null);
-        var validationResults = new List<ValidationResult>();
-        Validator.TryValidateObject(this, context, validationResults, true);
-        var extractValidationResults = ExtractValidationResults(validationResults);
-
-        foreach (var validationResult in extractValidationResults)
-        {
-            foreach (var memberName in validationResult.MemberNames)
-            {
-                if (IsModelTouched || TouchedProperties.Contains(memberName) || TouchedProperties.Any(p => p.StartsWith($"{memberName}.")))
-                {
-                    ModelState.AddModelError(memberName, validationResult.ErrorMessage!);
-                }
-            }
-        }
-
-        IsValid = ModelState.IsValid;
-
-        return IsValid;
-    }
-
-    private static IEnumerable<ValidationResult> ExtractValidationResults(IEnumerable<ValidationResult> validationResults)
-    {
-        foreach (var result in validationResults)
-        {
-            yield return result;
-
-            if (result is ICompositeValidationResult compositeResult)
-            {
-                foreach (var innerResult in compositeResult.Results)
-                {
-                    yield return innerResult;
-                }
-            }
-        }
-    }
-
-    private async Task<bool> AuthorizeAsync()
-    {
-        var type = GetType();
-
-        if (!ComponentAuthorizationAttributes.ContainsKey(type))
-        {
-            ComponentAuthorizationAttributes.TryAdd(type, type.GetCustomAttributes(true)
-                .Where(attr => attr is IHydroAuthorizationFilter)
-                .Cast<IHydroAuthorizationFilter>()
-                .ToArray());
-        }
-
-        foreach (var authorizationFilter in ComponentAuthorizationAttributes[type])
-        {
-            if (!await authorizationFilter.AuthorizeAsync(HttpContext, this))
-            {
-                if (HttpContext.IsHydro(excludeBoosted: true))
-                {
-                    HttpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
-                }
-
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /// <summary>
-    /// Queue JS to be executed on client side upon rendering component
-    /// </summary>
-    /// <param name="script"></param>
-    public void ExecuteJs(string script)
-    {
-        _clientScripts.Add(script);
-    }
-
-    private static string Hash(string input) =>
-        $"W{Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(input)))}";
-
-
-    /// <summary>
-    /// Binds model with the request Form if any and updates ModelState. WIth optional preValidate you can transform/check model values before they go to validation and even add your own validation errors. Return value is equal to  ModelState.IsValid.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="model"></param>
-    /// <param name="preValidate"></param>
-    /// <returns></returns>
-    public virtual async Task<bool> BindFormAndValidateAsync<T>(T model, Action<T, ModelStateDictionary> preValidate = null)
-    {
-        ModelState.Clear();
-        IsModelTouched = true;
-
-        var factory = HttpContext.RequestServices.GetRequiredService<IModelBinderFactory>();
-        var metadataProvider = HttpContext.RequestServices.GetRequiredService<IModelMetadataProvider>();
-        var modelMetadata = metadataProvider.GetMetadataForType(typeof(T));
-        var modelBinder = factory.CreateBinder(new ModelBinderFactoryContext
-        {
-            BindingInfo = new BindingInfo { BindingSource = BindingSource.Form },
-            Metadata = modelMetadata,
-            CacheToken = modelMetadata
-        });
-
-        var bindingInfo = new BindingInfo
-        {
-            BindingSource = BindingSource.Form
-        };
-
-        var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
-            ViewContext,
-            new CompositeValueProvider { new FormValueProvider(BindingSource.Form, HttpContext.Request.Form, CultureInfo.CurrentCulture) },
-            modelMetadata,
-            bindingInfo: bindingInfo,
-            modelName: typeof(T).Name);
-
-        modelBindingContext.Model = model;
-
-        await modelBinder.BindModelAsync(modelBindingContext);
-
-        preValidate?.Invoke(model, modelBindingContext.ModelState);
-
-        if (modelBindingContext.Result.IsModelSet)
-        {
-            var validationResults = new HashSet<ValidationResult>();
-            var isValid = Validator.TryValidateObject(model, new ValidationContext(model, HttpContext.RequestServices, null), validationResults, true);
-            if (!isValid)
-            {
-                foreach (var validationResult in validationResults)
-                {
-                    foreach (var memberName in validationResult.MemberNames)
-                    {
-                        modelBindingContext.ModelState.AddModelError(memberName, validationResult.ErrorMessage);
-                    }
-                }
-            }
-        }
-
-        if (!modelBindingContext.ModelState.IsValid)
-        {
-            foreach (var key in modelBindingContext.ModelState.Keys)
-            {
-                var values = modelBindingContext.ModelState[key];
-                if (values != null)
-                    foreach (var error in values.Errors)
-                    {
-                        ModelState.AddModelError(key, error.ErrorMessage);
-                    }
-            }
-        }
-
-        return ModelState.IsValid;
-    }
+	private string _componentId;
+	private bool _skipOutput;
+
+	private readonly ConcurrentDictionary<CacheKey, object> _requestCache = new();
+	private static readonly ConcurrentDictionary<CacheKey, object> PersistentCache = new();
+
+	private static readonly ConcurrentDictionary<Type, List<HydroPoll>> Polls = new();
+
+	private readonly List<string> _clientScripts = new();
+	private readonly List<HydroComponentEvent> _dispatchEvents = new();
+	private readonly HashSet<HydroEventSubscription> _subscriptions = new();
+
+	private static readonly MethodInfo InvokeActionMethod = typeof(HydroComponent).GetMethod(nameof(InvokeAction), BindingFlags.Static | BindingFlags.NonPublic);
+	private static readonly MethodInfo InvokeActionAsyncMethod = typeof(HydroComponent).GetMethod(nameof(InvokeActionAsync), BindingFlags.Static | BindingFlags.NonPublic);
+
+	public static readonly JsonSerializerSettings JsonSerializerSettings = new()
+	{
+		Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
+		ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+	};
+
+	private static readonly ConcurrentDictionary<Type, IHydroAuthorizationFilter[]> ComponentAuthorizationAttributes = new();
+	private HydroOptions _options;
+
+	/// <summary>
+	/// Provides indication if ModelState is valid
+	/// </summary>
+	protected bool IsValid { get; private set; }
+
+	/// <summary>
+	/// Provides component's key value
+	/// </summary>
+	protected string Key { get; private set; }
+
+	/// <summary>
+	/// Provides list of already accessed component's properties  
+	/// </summary>
+	public HashSet<string> TouchedProperties { get; set; } = new();
+
+	/// <summary>
+	/// Determines if the whole model was accessed already
+	/// </summary>
+	public bool IsModelTouched { get; set; }
+
+	/// <summary>
+	/// Determines if the current execution is related to the component mounting
+	/// </summary>
+	[Transient]
+	public bool IsMount { get; set; }
+
+	/// <summary>
+	/// Unique component identifier
+	/// </summary>
+	public string ComponentId => _componentId;
+
+	/// <summary />
+	public HydroComponent()
+	{
+		Subscribe<HydroBind>(data => SetPropertyValue(data.Name, data.Value));
+
+		ConfigurePolls();
+	}
+
+	private void ConfigurePolls()
+	{
+		var componentType = GetType();
+
+		if (Polls.ContainsKey(componentType))
+		{
+			return;
+		}
+
+		var methods = componentType
+			.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+			.Where(m => m.DeclaringType != typeof(HydroComponent))
+			.Select(m => (Method: m, Attribute: m.GetCustomAttribute<PollAttribute>()))
+			.Where(m => m.Attribute != null)
+			.Select(m => (m.Method, m.Attribute, ParametersCount: m.Method.GetParameters().Length))
+			.ToList();
+
+		if (methods.Any(p => p.Method.GetBaseDefinition() != p.Method))
+		{
+			throw new InvalidOperationException("Poll can be defined only on custom actions");
+		}
+
+		if (methods.Any(p => p.ParametersCount != 0))
+		{
+			throw new InvalidOperationException("Poll can be defined only on actions without parameters");
+		}
+
+		if (methods.Any(p => p.Attribute.Interval <= 0))
+		{
+			throw new InvalidOperationException("Polling's interval is invalid");
+		}
+
+		var polls = methods
+			.Select(p => new HydroPoll(p.Method.Name, TimeSpan.FromMilliseconds(p.Attribute.Interval)))
+			.ToList();
+
+		Polls.TryAdd(componentType, polls);
+	}
+
+	/// <summary>
+	/// Implementation of ViewComponent's InvokeAsync method
+	/// </summary>
+	/// <param name="parameters">Parameters</param>
+	/// <param name="key">Key</param>
+	public async Task<IHtmlContent> InvokeAsync(object parameters = null, string key = null)
+	{
+		var componentHtml = string.Empty;
+		if (ShouldRender())
+		{
+			await SetParametersAsync(parameters);
+
+			ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = null;
+			Key = key;
+
+			var persistentState = HttpContext.RequestServices.GetService<IPersistentState>();
+
+			_options = HttpContext.RequestServices.GetService<HydroOptions>();
+
+			if (persistentState == null || _options == null)
+			{
+				throw new ApplicationException("Hydro have not been initialized");
+			}
+
+			var firstRender = !IsMount;
+
+			try
+			{
+				//we need to for async threads called upon Dispatch, otherwise could just crash silently
+				componentHtml = HttpContext.IsHydro(excludeBoosted: true)
+					? await RenderOnlineComponent(persistentState)
+					: await RenderStaticComponent(persistentState);
+			}
+			catch (Exception e)
+			{
+				HandleError(e);
+			}
+
+			await OnAfterRenderAsync(firstRender);
+		}
+
+		return new HtmlString(componentHtml);
+	}
+
+	public virtual void HandleError(Exception e)
+	{
+		var message = $"{e.Message} {e.StackTrace}";
+		Debug.WriteLine(message);
+		Dispatch(new UnhandledHydroError(message, e), Scope.Global);
+	}
+
+	/// <summary>
+	/// Method invoked after each time the component has been rendered.
+	/// </summary>
+	/// <param name="firstRender">
+	/// Set to <c>true</c> if this is the first time it was rendered
+	/// </param>
+	protected virtual Task OnAfterRenderAsync(bool firstRender)
+		=> Task.CompletedTask;
+
+	/// <summary>
+	/// Subscribes to a Hydro event
+	/// </summary>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Subscribe<TEvent>(Func<string> subject = null) =>
+		_subscriptions.Add(new HydroEventSubscription
+		{
+			EventName = GetFullTypeName(typeof(TEvent)),
+			SubjectRetriever = subject,
+			Action = (TEvent _) => { }
+		});
+
+	/// <summary>
+	/// Subscribes to a Hydro event
+	/// </summary>
+	/// <param name="action">Action to execute when event occurs</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Subscribe<TEvent>(Action<TEvent> action) =>
+		_subscriptions.Add(new HydroEventSubscription
+		{
+			EventName = GetFullTypeName(typeof(TEvent)),
+			Action = action
+		});
+
+	/// <summary>
+	/// Subscribes to a Hydro event
+	/// </summary>
+	/// <param name="subject">Subject</param>
+	/// <param name="action">Action to execute when event occurs</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Subscribe<TEvent>(Func<string> subject, Action<TEvent> action) =>
+		_subscriptions.Add(new HydroEventSubscription
+		{
+			EventName = GetFullTypeName(typeof(TEvent)),
+			SubjectRetriever = subject,
+			Action = action
+		});
+
+	private static string GetFullTypeName(Type type) =>
+		type.DeclaringType != null
+			? type.DeclaringType.Name + "+" + type.Name
+			: type.Name;
+
+	/// <summary>
+	/// Subscribes to a Hydro event
+	/// </summary>
+	/// <param name="action">Action to execute when event occurs</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Subscribe<TEvent>(Func<TEvent, Task> action) =>
+		_subscriptions.Add(new HydroEventSubscription
+		{
+			EventName = GetFullTypeName(typeof(TEvent)),
+			Action = action
+		});
+
+	/// <summary>
+	/// Subscribes to a Hydro event
+	/// </summary>
+	/// <param name="subject">Subject</param>
+	/// <param name="action">Action to execute when event occurs</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Subscribe<TEvent>(Func<string> subject, Func<TEvent, Task> action) =>
+		_subscriptions.Add(new HydroEventSubscription
+		{
+			EventName = GetFullTypeName(typeof(TEvent)),
+			Action = action,
+			SubjectRetriever = subject
+		});
+
+	/// <summary>
+	/// Unsubscribe from a Hydro event
+	/// </summary>
+	/// <typeparam name="TEvent"></typeparam>
+	public void Unsubscribe<TEvent>()
+	{
+		var found = _subscriptions.RemoveWhere(x => x.EventName == typeof(TEvent).Name);
+	}
+
+	/// <summary>
+	/// Triggers a Hydro event
+	/// </summary>
+	/// <param name="data">Data to pass</param>
+	/// <param name="scope">Scope of the event</param>
+	/// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Dispatch<TEvent>(TEvent data, Scope scope = Scope.Parent, bool asynchronous = false) =>
+		Dispatch(GetFullTypeName(typeof(TEvent)), data, scope, asynchronous);
+
+	/// <summary>
+	/// Triggers a Hydro event
+	/// </summary>
+	/// <param name="name">Name of the event</param>
+	/// <param name="data">Data to pass</param>
+	/// <param name="scope">Scope of the event</param>
+	/// <param name="subject">Subject</param>
+	/// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void Dispatch<TEvent>(string name, TEvent data, Scope scope = Scope.Parent, bool asynchronous = false, string subject = null)
+	{
+		var operationId = !asynchronous && HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
+			? incomingOperationId.First()
+			: Guid.NewGuid().ToString("N");
+
+		_dispatchEvents.Add(new HydroComponentEvent
+		{
+			Name = name,
+			Data = data,
+			Scope = scope.ToString().ToLower(),
+			Subject = subject,
+			OperationId = operationId
+		});
+	}
+
+	/// <summary>
+	/// Triggers a Hydro event in a global scope
+	/// </summary>
+	/// <param name="data">Data to pass</param>
+	/// <param name="subject">Subject</param>
+	/// <param name="asynchronous">Do not chain the execution of handlers and run them separately</param>
+	/// <typeparam name="TEvent">Event type</typeparam>
+	public void DispatchGlobal<TEvent>(TEvent data, string subject = null, bool asynchronous = false) =>
+		Dispatch(GetFullTypeName(typeof(TEvent)), data, Scope.Global, asynchronous, subject);
+
+	/// <summary>
+	/// Provides actions that can be executed on client side
+	/// </summary>
+	public HydroClientActions Client { get; } = new();
+
+	/// <summary>
+	/// Triggered once the component is mounted
+	/// </summary>
+	public virtual Task MountAsync()
+	{
+		Mount();
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Triggered once the component is mounted
+	/// </summary>
+	public virtual void Mount()
+	{
+	}
+
+	/// <summary>
+	/// Triggered before each render
+	/// </summary>
+	public virtual Task RenderAsync()
+	{
+		Render();
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Returns a flag to indicate whether the component should render.
+	/// </summary>
+	/// <returns></returns>
+	protected virtual bool ShouldRender()
+		=> true;
+
+	/// <summary>
+	/// Triggered before each render
+	/// </summary>
+	public virtual void Render()
+	{
+	}
+
+	/// <summary>
+	/// Perform a redirect with page reload
+	/// </summary>
+	/// <param name="url">Destination URL</param>
+	public void Redirect(string url) =>
+		HttpContext.Response.HydroRedirect(url);
+
+	/// <summary>
+	/// Perform a redirect without page reload
+	/// </summary>
+	/// <param name="url">Destination URL</param>
+	/// <param name="payload">Payload for the destination components</param>
+	public void Location(string url, object payload = null) =>
+		HttpContext.Response.HydroLocation(url, payload);
+
+	/// <summary>
+	/// Perform a redirect without page reload, but intead of replacing the whole body replaces the specified element. Example "#renderBody" or "renderBody" etc..
+	/// </summary>
+	/// <param name="url"></param>
+	/// <param name="target"></param>
+	/// <param name="payload"></param>
+	public void Location(string url, string target, object payload = null) =>
+		HttpContext.Response.HydroLocation(url, target, payload);
+
+	/// <summary>
+	/// Cache value
+	/// </summary>
+	/// <param name="func">Value producer</param>
+	/// <param name="lifetime">Lifetime of the cached value</param>
+	/// <typeparam name="T">Type of the value</typeparam>
+	/// <returns>Produced value</returns>
+	protected Cache<T> Cache<T>(Func<T> func, CacheLifetime lifetime = CacheLifetime.Request)
+	{
+		var cache = lifetime == CacheLifetime.Request ? _requestCache : PersistentCache;
+
+		var cacheKey = new CacheKey(_componentId, func);
+		if (cache.TryGetValue(cacheKey, out var dic))
+		{
+			var value = (Cache<T>)dic;
+
+			if (!value.IsSet)
+			{
+				cache.Remove(cacheKey, out _);
+			}
+			else
+			{
+				return value;
+			}
+		}
+
+		var cacheValue = new Cache<T>(func);
+		cache.TryAdd(cacheKey, cacheValue);
+		return cacheValue;
+	}
+
+	private async Task<string> RenderOnlineComponent(IPersistentState persistentState) =>
+		DetermineRootComponent()
+			? await RenderOnlineRootComponent(persistentState)
+			: await RenderOnlineNestedComponent(persistentState);
+
+	private bool DetermineRootComponent()
+	{
+		if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.IsRootRendered, out _))
+		{
+			HttpContext.Items.TryAdd(HydroConsts.ContextItems.IsRootRendered, true);
+			return true;
+		}
+
+		return false;
+	}
+
+	private async Task<string> RenderOnlineRootComponent(IPersistentState persistentState)
+	{
+		var componentId = GetRootComponentId();
+		_componentId = componentId;
+
+		PopulateBaseModel(persistentState);
+		await PopulateRequestModel();
+		if (!await AuthorizeAsync())
+		{
+			return string.Empty;
+		}
+
+		await TriggerEvent();
+
+		ValidateTouched();
+
+		await TriggerMethod();
+
+		if (!_skipOutput)
+		{
+			await RenderAsync();
+		}
+
+		PopulateDispatchers();
+
+		PopulateClientScripts();
+
+		return !_skipOutput
+			? await GenerateComponentHtml(componentId, persistentState, false)
+			: string.Empty;
+	}
+
+	private async Task<string> RenderOnlineNestedComponent(IPersistentState persistentState)
+	{
+		var componentId = GenerateComponentId(Key);
+		_componentId = componentId;
+
+		if (IsComponentIdRendered(componentId))
+		{
+			return GetComponentPlaceholderTemplate(componentId);
+		}
+
+		if (!await AuthorizeAsync())
+		{
+			return string.Empty;
+		}
+
+		IsMount = true;
+		await MountAsync();
+		await RenderAsync();
+		return await GenerateComponentHtml(componentId, persistentState, true);
+	}
+
+	private static string GetComponentPlaceholderTemplate(string componentId) =>
+		$"<div id=\"{componentId}\" key=\"{componentId}\" hydro hydro-placeholder></div>";
+
+	private async Task<string> RenderStaticComponent(IPersistentState persistentState)
+	{
+		var componentId = GenerateComponentId(Key);
+		_componentId = componentId;
+
+		if (!await AuthorizeAsync())
+		{
+			return string.Empty;
+		}
+
+		IsMount = true;
+		await MountAsync();
+		await RenderAsync();
+		return await GenerateComponentHtml(componentId, persistentState, true);
+	}
+
+	private string GenerateComponentId(string key)
+	{
+		var parentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
+		var mainId = parentComponentId ?? $"{Guid.NewGuid():N}";
+		var typeName = GetType().Name;
+
+
+		var generateComponentId = Hash($"{mainId}-{typeName}-{key}");
+		return generateComponentId;
+	}
+
+	private async Task<string> GenerateComponentHtml(string componentId, IPersistentState persistentState, bool isStatic)
+	{
+		var previousParentComponentId = HttpContext.Items[HydroConsts.Component.ParentComponentId];
+		HttpContext.Items[HydroConsts.Component.ParentComponentId] = componentId;
+
+		var componentHtmlDocument = await GetComponentHtml();
+
+		HttpContext.Items[HydroConsts.Component.ParentComponentId] = previousParentComponentId;
+
+		var root = componentHtmlDocument.DocumentNode;
+
+		if (root.ChildNodes.Count(n => n.NodeType == HtmlNodeType.Element) != 1)
+		{
+			throw new InvalidOperationException("The wire component must have only one root element.");
+		}
+
+		var rootElement = root.ChildNodes.First(n => n.NodeType == HtmlNodeType.Element);
+
+		rootElement.SetAttributeValue("id", componentId);
+		rootElement.SetAttributeValue("key", componentId);
+		rootElement.SetAttributeValue("hydro-name", GetType().Name);
+		rootElement.SetAttributeValue("x-data", "hydro");
+		var hydroAttribute = rootElement.SetAttributeValue("hydro", null);
+		hydroAttribute.QuoteType = AttributeValueQuote.WithoutValue;
+
+		if (Polls.TryGetValue(GetType(), out var polls))
+		{
+			for (var i = 0; i < polls.Count; i++)
+			{
+				rootElement.AppendChild(GetPollScript(componentHtmlDocument, polls[i], i));
+			}
+		}
+
+		rootElement.AppendChild(GetModelScript(componentHtmlDocument, componentId, persistentState));
+
+		foreach (var subscription in _subscriptions)
+		{
+			rootElement.AppendChild(GetEventSubscriptionScript(componentHtmlDocument, subscription));
+		}
+
+		if (isStatic)
+		{
+			foreach (var script in _clientScripts)
+			{
+				rootElement.AppendChild(GetStaticScript(componentHtmlDocument, script));
+			}
+		}
+
+		return rootElement.OuterHtml;
+	}
+
+	private async Task BindModel(IFormCollection formCollection)
+	{
+		if (!IsModelTouched)
+		{
+			if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out _))
+			{
+				IsModelTouched = true;
+			}
+			else
+			{
+				foreach (var item in formCollection)
+				{
+					TouchedProperties.Add(item.Key);
+				}
+			}
+		}
+
+		foreach (var pair in formCollection)
+		{
+			var setter = PropertyInjector.GetPropertySetter(this, pair.Key, pair.Value);
+			var propertyPath = PropertyPath.ExtractPropertyPath(pair.Key);
+
+			if (setter != null)
+			{
+				var value = setter.Value.Value == null
+					? null
+					: _options.ValueMappersDictionary.TryGetValue(setter.Value.Value.GetType(), out var mapper)
+						? await mapper.Map(setter.Value.Value)
+						: setter.Value.Value;
+
+				setter.Value.Setter(value);
+				await BindAsync(propertyPath, value);
+			}
+			else
+			{
+				await BindAsync(propertyPath, null);
+			}
+		}
+
+		foreach (var file in formCollection.Files)
+		{
+			var setter = PropertyInjector.GetPropertySetter(this, file.Name, file);
+			var propertyPath = PropertyPath.ExtractPropertyPath(file.Name);
+
+			if (setter != null)
+			{
+				setter.Value.Setter(file);
+				await BindAsync(propertyPath, file);
+			}
+			else
+			{
+				await BindAsync(propertyPath, null);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Applies value to a component
+	/// </summary>
+	/// <param name="path">Path to the value</param>
+	/// <param name="value">Value</param>
+	public async Task SetPropertyValue(string path, object value)
+	{
+		PropertyInjector.SetPropertyValue(this, path, value);
+		TouchedProperties.Add(path);
+		await BindAsync(PropertyPath.ExtractPropertyPath(path), value);
+	}
+
+	/// <summary>
+	/// Triggered when a property is updated from the client
+	/// </summary>
+	/// <param name="property">Property path</param>
+	/// <param name="value">New value</param>
+	public virtual void Bind(PropertyPath property, object value)
+	{
+	}
+
+	/// <summary>
+	/// Triggered when a property is updated from the client
+	/// </summary>
+	/// <param name="property">Property path</param>
+	/// <param name="value">New value</param>
+	public virtual Task BindAsync(PropertyPath property, object value)
+	{
+		Bind(property, value);
+		return Task.CompletedTask;
+	}
+
+	private HtmlNode GetModelScript(HtmlDocument document, string id, IPersistentState persistentState)
+	{
+		var scriptNode = document.CreateElement("script");
+		scriptNode.SetAttributeValue("type", "text/hydro");
+		scriptNode.SetAttributeValue("data-id", id);
+		var serializeDeclaredProperties = PropertyInjector.SerializeDeclaredProperties(GetType(), this);
+		var model = persistentState.Protect(serializeDeclaredProperties);
+		scriptNode.AppendChild(document.CreateTextNode(model));
+		return scriptNode;
+	}
+
+	private HtmlNode GetEventSubscriptionScript(HtmlDocument document, HydroEventSubscription subscription)
+	{
+		var eventData = new
+		{
+			name = subscription.EventName,
+			subject = subscription.SubjectRetriever?.Invoke(),
+			path = $"/hydro/{GetType().Name}/event".ToLower()
+		};
+
+		var scriptNode = document.CreateElement("script");
+		scriptNode.SetAttributeValue("key", $"R{Guid.NewGuid():N}");
+		scriptNode.SetAttributeValue("type", "text/hydro");
+		scriptNode.SetAttributeValue("hydro-event", "true");
+		scriptNode.SetAttributeValue("x-data", "");
+		scriptNode.SetAttributeValue("x-on-hydro-event", JsonConvert.SerializeObject(eventData, JsonSerializerSettings));
+		return scriptNode;
+	}
+
+	private HtmlNode GetPollScript(HtmlDocument document, HydroPoll poll, int index)
+	{
+		var scriptNode = document.CreateElement("script");
+		scriptNode.SetAttributeValue($"x-hydro-polling.{poll.Interval.TotalMilliseconds}ms._{index}", poll.Action);
+		scriptNode.SetAttributeValue("type", "text/hydro");
+		return scriptNode;
+	}
+
+	private HtmlNode GetStaticScript(HtmlDocument document, string script)
+	{
+		var scriptNode = document.CreateElement("script");
+		scriptNode.SetAttributeValue("hydro-js", "true");
+		scriptNode.SetAttributeValue("type", "text/hydro");
+		scriptNode.InnerHtml = script;
+		return scriptNode;
+	}
+
+	private void PopulateDispatchers()
+	{
+		if (!_dispatchEvents.Any())
+		{
+			return;
+		}
+
+		var data = _dispatchEvents
+			.Select(e => new
+			{
+				name = e.Name,
+				data = Base64.Serialize(e.Data),
+				scope = e.Scope,
+				subject = e.Subject,
+				operationId = e.OperationId
+			})
+			.ToList();
+
+		HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Trigger, JsonConvert.SerializeObject(data, JsonSerializerSettings));
+	}
+
+	private void PopulateClientScripts()
+	{
+		if (!_clientScripts.Any())
+		{
+			return;
+		}
+
+		HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.Scripts, JsonConvert.SerializeObject(_clientScripts, JsonSerializerSettings));
+
+		_clientScripts.Clear();
+	}
+
+	private bool IsComponentIdRendered(string componentId)
+	{
+		var renderedComponentIds = (string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds];
+		return renderedComponentIds.Contains(componentId);
+	}
+
+	private async Task TriggerMethod()
+	{
+		if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.MethodName, out var method)
+			|| method is not string methodValue || string.IsNullOrWhiteSpace(methodValue))
+		{
+			return;
+		}
+
+		var methodInfos = GetType()
+			.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+		var requestParameters = (IDictionary<string, object>)HttpContext.Items[HydroConsts.ContextItems.Parameters];
+
+		var methodInfo = methodInfos.FirstOrDefault(m =>
+			string.Equals(m.Name, methodValue, StringComparison.OrdinalIgnoreCase)
+			&& m.GetParameters().Select(p => p.Name).SequenceEqual(requestParameters.Select(p => p.Key))
+		);
+
+		if (methodInfo == null)
+		{
+			return;
+		}
+
+		var methodParameters = methodInfo.GetParameters();
+		var methodAttributes = methodInfo.GetCustomAttributes();
+
+		if (requestParameters.Count != methodParameters.Length
+			|| requestParameters.Any(rp => !methodParameters.Any(mp => rp.Key == mp.Name)))
+		{
+			throw new InvalidOperationException("Wrong action parameters");
+		}
+
+		if (methodAttributes.Any(a => a.GetType() == typeof(SkipOutputAttribute)))
+		{
+			_skipOutput = true;
+			HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.SkipOutput, "True");
+		}
+
+		var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
+			? incomingOperationId.First()
+			: Guid.NewGuid().ToString("N");
+
+		HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
+
+		var orderedParameters = methodParameters
+			.Select(p =>
+			{
+				var requestParameter = requestParameters[p.Name!];
+
+				if (requestParameter == null)
+				{
+					return null;
+				}
+
+				var sourceType = requestParameter.GetType();
+
+				if (p.ParameterType == sourceType)
+				{
+					return requestParameter;
+				}
+
+				if (p.ParameterType.IsEnum)
+				{
+					return Enum.ToObject(p.ParameterType, requestParameter);
+				}
+
+				return TypeDescriptor.GetConverter(p.ParameterType).ConvertFrom(requestParameter);
+			})
+			.ToArray();
+
+		if (typeof(Task).IsAssignableFrom(methodInfo.ReturnType))
+		{
+			await (Task)methodInfo.Invoke(this, orderedParameters)!;
+		}
+		else
+		{
+			methodInfo.Invoke(this, orderedParameters);
+		}
+	}
+
+	/// <summary>
+	/// Get the payload transferred from previous page's component
+	/// </summary>
+	/// <typeparam name="T">Payload type</typeparam>
+	/// <returns>Payload</returns>
+	public T GetPayload<T>() =>
+		HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.Payload, out var payloadString)
+			? JsonConvert.DeserializeObject<T>(payloadString)
+			: default;
+
+	private async Task TriggerEvent()
+	{
+		if (!HttpContext.Items.TryGetValue(HydroConsts.ContextItems.EventName, out var eventName)
+			|| eventName is not string eventNameValue || string.IsNullOrWhiteSpace(eventNameValue))
+		{
+			return;
+		}
+
+		var eventSubject = (string)HttpContext.Items[HydroConsts.ContextItems.EventSubject];
+		var subscriptions = _subscriptions
+			.Where(s => s.EventName == eventNameValue && (s.SubjectRetriever == null || s.SubjectRetriever() == eventSubject))
+			.ToList();
+
+		foreach (var subscription in subscriptions)
+		{
+			var methodInfo = subscription.Action.Method;
+			var parameters = methodInfo.GetParameters();
+			var parameterType = parameters.First().ParameterType;
+			var model = Base64.Deserialize((string)HttpContext.Items[HydroConsts.ContextItems.EventData], parameterType);
+
+			var operationId = HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.OperationId, out var incomingOperationId)
+				? incomingOperationId.First()
+				: Guid.NewGuid().ToString("N");
+
+			HttpContext.Response.Headers.TryAdd(HydroConsts.ResponseHeaders.OperationId, operationId);
+
+			var isAsync = typeof(Task).IsAssignableFrom(methodInfo.ReturnType);
+
+			if (isAsync)
+			{
+				var method = InvokeActionAsyncMethod.MakeGenericMethod(parameterType);
+				await (Task)method.Invoke(null, new[] { subscription.Action, model })!;
+			}
+			else
+			{
+				var method = InvokeActionMethod.MakeGenericMethod(parameterType);
+				method.Invoke(null, new[] { subscription.Action, model });
+			}
+		}
+	}
+
+	private static void InvokeAction<T>(Delegate actionDelegate, T instance)
+	{
+		var action = actionDelegate as Action<T>;
+		action?.Invoke(instance);
+	}
+
+	private static Task InvokeActionAsync<T>(Delegate actionDelegate, T instance)
+	{
+		var action = actionDelegate as Func<T, Task>;
+		return action!.Invoke(instance);
+	}
+
+	private void PopulateBaseModel(IPersistentState persistentState)
+	{
+		if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.BaseModel, out var baseModel))
+		{
+			var unprotect = persistentState.Unprotect((string)baseModel);
+			JsonConvert.PopulateObject(unprotect, this);
+		}
+	}
+
+	private async Task PopulateRequestModel()
+	{
+		if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.RequestForm, out var requestForm))
+		{
+			await BindModel((IFormCollection)requestForm);
+		}
+	}
+
+	private string GetRootComponentId() =>
+		((string[])HttpContext.Items[HydroConsts.ContextItems.RenderedComponentIds]).First();
+
+	private string GetViewPath() =>
+		ViewPath ?? GetViewPath(GetType());
+
+	/// <summary>
+	/// Get the view path based on the type
+	/// </summary>
+	protected string GetViewPath(Type type)
+	{
+		var assemblyName = type.Assembly.GetName().Name;
+		return $"{type.FullName!.Replace(assemblyName!, "~").Replace(".", "/")}.cshtml";
+	}
+
+	/// Get the view path based on the view name
+	protected string GetViewPath(string viewName)
+	{
+		var type = GetType();
+		return GetViewPath(type).Replace($"{type.Name}.cshtml", $"{viewName}.cshtml");
+	}
+
+	/// <summary>
+	/// Override this property if you want to use custom view path for the component
+	/// </summary>
+	public virtual string ViewPath => null;
+
+	private async Task<HtmlDocument> GetComponentHtml()
+	{
+		using var stream = new MemoryStream();
+		await using var writer = new StreamWriter(stream);
+
+		var previousWriter = ViewComponentContext.ViewContext.Writer;
+		ViewComponentContext.ViewContext.Writer = writer;
+		ViewComponentContext.ViewContext.CheckBoxHiddenInputRenderMode = CheckBoxHiddenInputRenderMode.None;
+
+		var result = View(GetViewPath(), this);
+
+		await result.ExecuteAsync(ViewComponentContext);
+		await writer.FlushAsync();
+
+		stream.Position = 0;
+		var htmlDocument = new HtmlDocument();
+		htmlDocument.Load(stream);
+		ViewComponentContext.ViewContext.Writer = previousWriter;
+		return htmlDocument;
+	}
+
+	/// <summary>
+	/// Method invoked when the component has received parameters from its parent in
+	/// the render tree, and the incoming values have been assigned to properties.
+	/// </summary>
+	/// <returns>A <see cref="Task"/> representing any asynchronous operation.</returns>
+	protected virtual Task OnParametersSetAsync()
+		=> Task.CompletedTask;
+
+	/// <summary>
+	/// Method invoked when the component has received parameters from its parent in
+	/// the render tree, and the incoming values have been assigned to properties.	/// </summary>
+	/// <param name="parameters"></param>
+	/// <returns></returns>
+	public virtual async Task SetParametersAsync(object parameters)
+	{
+		switch (parameters)
+		{
+		case null:
+		return;
+
+		case IDictionary<string, object> dictionary:
+		ApplyObjectFromDictionary(this, dictionary);
+		break;
+
+		default:
+		ApplyObject(this, parameters);
+		break;
+		}
+
+		await OnParametersSetAsync();
+	}
+
+	private void ApplyObject<T>(T target, object source)
+	{
+		if (source == null || target == null)
+		{
+			return;
+		}
+
+		var sourceType = source.GetType();
+		var targetType = target.GetType();
+
+		foreach (var sourceProperty in sourceType.GetProperties())
+		{
+			var targetProperty = targetType.GetProperty(sourceProperty.Name);
+
+			if (targetProperty == null || !targetProperty.CanWrite)
+			{
+				continue;
+			}
+
+			object sourceValue;
+
+			if (sourceProperty.PropertyType == targetProperty.PropertyType)
+			{
+				sourceValue = sourceProperty.GetValue(source);
+			}
+			else
+			{
+				try
+				{
+					var json = JsonConvert.SerializeObject(sourceProperty.GetValue(source), JsonSerializerSettings);
+					sourceValue = JsonConvert.DeserializeObject(json, targetProperty.PropertyType);
+				}
+				catch
+				{
+					throw new InvalidCastException($"Type mismatch in {sourceProperty.Name} parameter.");
+				}
+			}
+
+			targetProperty.SetValue(target, sourceValue);
+		}
+	}
+
+	private void ApplyObjectFromDictionary<T>(T target, IDictionary<string, object> source)
+	{
+		if (source == null || target == null)
+		{
+			return;
+		}
+
+		var targetType = target.GetType();
+
+		foreach (var sourceProperty in source)
+		{
+			var targetProperty = targetType.GetProperty(sourceProperty.Key, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+
+			if (targetProperty == null || !targetProperty.CanWrite)
+			{
+				continue;
+			}
+
+			var value = sourceProperty.Value;
+
+			if (value != null && !targetProperty.PropertyType.IsInstanceOfType(value))
+			{
+				throw new InvalidCastException($"Type mismatch in {sourceProperty.Key} parameter.");
+			}
+
+			targetProperty.SetValue(target, value);
+		}
+	}
+
+	/// <summary>
+	/// Validate the model state
+	/// </summary>
+	/// <returns>True if the state is valid</returns>
+	public bool Validate()
+	{
+		IsModelTouched = true;
+		return ValidateTouched();
+	}
+
+	private bool ValidateTouched()
+	{
+		ModelState.Clear();
+
+		var context = new ValidationContext(this, serviceProvider: HttpContext.RequestServices, items: null);
+		var validationResults = new List<ValidationResult>();
+		Validator.TryValidateObject(this, context, validationResults, true);
+		var extractValidationResults = ExtractValidationResults(validationResults);
+
+		foreach (var validationResult in extractValidationResults)
+		{
+			foreach (var memberName in validationResult.MemberNames)
+			{
+				if (IsModelTouched || TouchedProperties.Contains(memberName) || TouchedProperties.Any(p => p.StartsWith($"{memberName}.")))
+				{
+					ModelState.AddModelError(memberName, validationResult.ErrorMessage!);
+				}
+			}
+		}
+
+		IsValid = ModelState.IsValid;
+
+		return IsValid;
+	}
+
+	private static IEnumerable<ValidationResult> ExtractValidationResults(IEnumerable<ValidationResult> validationResults)
+	{
+		foreach (var result in validationResults)
+		{
+			yield return result;
+
+			if (result is ICompositeValidationResult compositeResult)
+			{
+				foreach (var innerResult in compositeResult.Results)
+				{
+					yield return innerResult;
+				}
+			}
+		}
+	}
+
+	private async Task<bool> AuthorizeAsync()
+	{
+		var type = GetType();
+
+		if (!ComponentAuthorizationAttributes.ContainsKey(type))
+		{
+			ComponentAuthorizationAttributes.TryAdd(type, type.GetCustomAttributes(true)
+				.Where(attr => attr is IHydroAuthorizationFilter)
+				.Cast<IHydroAuthorizationFilter>()
+				.ToArray());
+		}
+
+		foreach (var authorizationFilter in ComponentAuthorizationAttributes[type])
+		{
+			if (!await authorizationFilter.AuthorizeAsync(HttpContext, this))
+			{
+				if (HttpContext.IsHydro(excludeBoosted: true))
+				{
+					HttpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+				}
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Queue JS to be executed on client side upon rendering component
+	/// </summary>
+	/// <param name="script"></param>
+	public void ExecuteJs(string script)
+	{
+		_clientScripts.Add(script);
+	}
+
+	private static string Hash(string input) =>
+		$"W{Convert.ToHexString(MD5.HashData(Encoding.ASCII.GetBytes(input)))}";
+
+
+	/// <summary>
+	/// Binds model with the request Form if any and updates ModelState. WIth optional preValidate you can transform/check model values before they go to validation and even add your own validation errors. Return value is equal to  ModelState.IsValid.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="model"></param>
+	/// <param name="preValidate"></param>
+	/// <returns></returns>
+	public virtual async Task<bool> BindFormAndValidateAsync<T>(T model, Action<T, ModelStateDictionary> preValidate = null)
+	{
+		ModelState.Clear();
+		IsModelTouched = true;
+
+		var factory = HttpContext.RequestServices.GetRequiredService<IModelBinderFactory>();
+		var metadataProvider = HttpContext.RequestServices.GetRequiredService<IModelMetadataProvider>();
+		var modelMetadata = metadataProvider.GetMetadataForType(typeof(T));
+		var modelBinder = factory.CreateBinder(new ModelBinderFactoryContext
+		{
+			BindingInfo = new BindingInfo { BindingSource = BindingSource.Form },
+			Metadata = modelMetadata,
+			CacheToken = modelMetadata
+		});
+
+		var bindingInfo = new BindingInfo
+		{
+			BindingSource = BindingSource.Form
+		};
+
+		var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
+			ViewContext,
+			new CompositeValueProvider { new FormValueProvider(BindingSource.Form, HttpContext.Request.Form, CultureInfo.CurrentCulture) },
+			modelMetadata,
+			bindingInfo: bindingInfo,
+			modelName: typeof(T).Name);
+
+		modelBindingContext.Model = model;
+
+		await modelBinder.BindModelAsync(modelBindingContext);
+
+		preValidate?.Invoke(model, modelBindingContext.ModelState);
+
+		if (modelBindingContext.Result.IsModelSet)
+		{
+			var validationResults = new HashSet<ValidationResult>();
+			var isValid = Validator.TryValidateObject(model, new ValidationContext(model, HttpContext.RequestServices, null), validationResults, true);
+			if (!isValid)
+			{
+				foreach (var validationResult in validationResults)
+				{
+					foreach (var memberName in validationResult.MemberNames)
+					{
+						modelBindingContext.ModelState.AddModelError(memberName, validationResult.ErrorMessage);
+					}
+				}
+			}
+		}
+
+		if (!modelBindingContext.ModelState.IsValid)
+		{
+			foreach (var key in modelBindingContext.ModelState.Keys)
+			{
+				var values = modelBindingContext.ModelState[key];
+				if (values != null)
+					foreach (var error in values.Errors)
+					{
+						ModelState.AddModelError(key, error.ErrorMessage);
+					}
+			}
+		}
+
+		return ModelState.IsValid;
+	}
 }

--- a/src/HydroComponent.cs
+++ b/src/HydroComponent.cs
@@ -360,6 +360,15 @@ public abstract class HydroComponent : ViewComponent
         HttpContext.Response.HydroLocation(url, payload);
 
     /// <summary>
+    /// Perform a redirect without page reload, but intead of replacing the whole body replaces the specified element. Example "#renderBody" or "renderBody" etc..
+    /// </summary>
+    /// <param name="url"></param>
+    /// <param name="target"></param>
+    /// <param name="payload"></param>
+    public void Location(string url, string target, object payload = null) =>
+        HttpContext.Response.HydroLocation(url, target, payload);
+
+    /// <summary>
     /// Cache value
     /// </summary>
     /// <param name="func">Value producer</param>

--- a/src/HydroConsts.cs
+++ b/src/HydroConsts.cs
@@ -16,6 +16,7 @@ internal static class HydroConsts
         public const string OperationId = "Hydro-Operation-Id";
         public const string SkipOutput = "Hydro-Skip-Output";
         public const string RefreshToken = "Refresh-Antiforgery-Token";
+        public const string Scripts = "Hydro-Js";
     }
 
     public static class ContextItems

--- a/src/HydroHtmlExtensions.cs
+++ b/src/HydroHtmlExtensions.cs
@@ -1,6 +1,9 @@
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Text.Encodings.Web;
 
 namespace Hydro;
 
@@ -13,21 +16,48 @@ public static class HydroHtmlExtensions
     public static Task<IHtmlContent> Hydro<TComponent>(this IViewComponentHelper helper, object parameters = null, string key = null) where TComponent : HydroComponent
     {
         var arguments = parameters != null || key != null
-            ? new { parameters, key } 
+            ? new { parameters, key }
             : null;
-        
-        return helper.InvokeAsync(typeof (TComponent), arguments);
+
+        return helper.InvokeAsync(typeof(TComponent), arguments);
     }
-    
+
     /// <summary>
     /// Renders hydro component
     /// </summary>
-    public static Task<IHtmlContent> Hydro(this IViewComponentHelper helper, [AspMvcViewComponent]string hydroComponentName, object parameters = null, string key = null)
+    public static Task<IHtmlContent> Hydro(this IViewComponentHelper helper, [AspMvcViewComponent] string hydroComponentName, object parameters = null, string key = null)
     {
         var arguments = parameters != null || key != null
-            ? new { parameters, key } 
+            ? new { parameters, key }
             : null;
-        
+
         return helper.InvokeAsync(hydroComponentName, arguments);
     }
+
+    internal class WriteBody : IHtmlContent
+    {
+        private readonly IHtmlContent _body;
+
+        public WriteBody(IHtmlContent body)
+        {
+            _body = body;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            writer.Write("<div id='hydro-location'>");
+            _body.WriteTo(writer, encoder);
+            writer.Write("</div>");
+        }
+    }
+
+    /// <summary>
+    /// To use @Html.HydroBody(RenderBody()) instead of RenderBody() to support ajax loads auto-target. This way in your _ViewStart you could set: Layout = Context.IsHydroBoosted() ? null : "_Layout"; and enjoy faster loads.
+    /// </summary>
+    /// <param name="htmlHelper"></param>
+    /// <param name="bodyContent"></param>
+    /// <returns></returns>
+    public static IHtmlContent HydroBody(this IHtmlHelper htmlHelper, IHtmlContent body)
+        => new WriteBody(body);
+
 }

--- a/src/HydroHttpResponseExtensions.cs
+++ b/src/HydroHttpResponseExtensions.cs
@@ -20,27 +20,43 @@ public static class HydroHttpResponseExtensions
         {
             throw new ArgumentException("url is not provided", nameof(url));
         }
-        
+
         response.Headers.Add("Hydro-Redirect", new StringValues(url));
     }
 
     /// <summary>
-    /// Add a response header that instructs Hydro to redirect to a specific page without page reload
+    /// Add a response header that instructs Hydro to redirect to a specific page without page reload to replace body element
     /// </summary>
     /// <param name="response">HttpResponse instance</param>
     /// <param name="url">URL to redirect to</param>
     /// <param name="payload">Object to pass to destination page</param>
     public static void HydroLocation(this HttpResponse response, string url, object payload = null)
     {
+        HydroLocation(response, url, "", payload);
+    }
+
+    /// <summary>
+    /// Add a response header that instructs Hydro to redirect to a specific page without page reload, to replace the specified element
+    /// </summary>
+    /// <param name="response"></param>
+    /// <param name="url"></param>
+    /// <param name="targetElement"></param>
+    /// <param name="payload"></param>
+    /// <exception cref="ArgumentException"></exception>
+    public static void HydroLocation(this HttpResponse response,
+        string url,
+        string targetElement,
+        object payload = null)
+    {
         if (string.IsNullOrWhiteSpace(url))
         {
             throw new ArgumentException("url is not provided", nameof(url));
         }
-        
+
         var data = new
         {
             path = url,
-            target = "body",
+            target = targetElement,
             payload
         };
 

--- a/src/PropertyInjector.cs
+++ b/src/PropertyInjector.cs
@@ -1,292 +1,292 @@
-﻿using System.Collections;
-using System.Collections.Concurrent;
-using System.ComponentModel;
-using System.Reflection;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Reflection;
 
 namespace Hydro;
 
 internal static class PropertyInjector
 {
-    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> CachedPropertyInfos = new();
-    private static readonly ConcurrentDictionary<string, PropertyInfo> PropertyCache = new();
+	private static readonly ConcurrentDictionary<Type, PropertyInfo[]> CachedPropertyInfos = new();
+	private static readonly ConcurrentDictionary<string, PropertyInfo> PropertyCache = new();
 
-    public static string SerializeDeclaredProperties(Type type, object instance)
-    {
-        var regularProperties = GetRegularProperties(type, instance);
-        return JsonConvert.SerializeObject(regularProperties);
-    }
+	public static string SerializeDeclaredProperties(Type type, object instance)
+	{
+		var regularProperties = GetRegularProperties(type, instance);
+		return JsonConvert.SerializeObject(regularProperties, HydroComponent.JsonSerializerSettings);
+	}
 
-    private static IDictionary<string, object> GetRegularProperties(Type type, object instance) =>
-        GetPropertyInfos(type).ToDictionary(p => p.Name, p => p.GetValue(instance));
+	private static IDictionary<string, object> GetRegularProperties(Type type, object instance) =>
+		GetPropertyInfos(type).ToDictionary(p => p.Name, p => p.GetValue(instance));
 
-    private static IEnumerable<PropertyInfo> GetPropertyInfos(Type type)
-    {
-        if (CachedPropertyInfos.TryGetValue(type, out var properties))
-        {
-            return properties;
-        }
+	private static IEnumerable<PropertyInfo> GetPropertyInfos(Type type)
+	{
+		if (CachedPropertyInfos.TryGetValue(type, out var properties))
+		{
+			return properties;
+		}
 
-        var propertyInfos = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-            .Where(p => (p.DeclaringType != typeof(ViewComponent)) && p.GetSetMethod()?.IsPublic == true && !p.GetCustomAttributes<TransientAttribute>().Any())
-            .ToArray();
+		var propertyInfos = type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+			.Where(p => (p.DeclaringType != typeof(ViewComponent)) && p.GetSetMethod()?.IsPublic == true && !p.GetCustomAttributes<TransientAttribute>().Any())
+			.ToArray();
 
-        CachedPropertyInfos.TryAdd(type, propertyInfos);
+		CachedPropertyInfos.TryAdd(type, propertyInfos);
 
-        return propertyInfos;
-    }
+		return propertyInfos;
+	}
 
-    public static void SetPropertyValue(object target, string propertyPath, object value)
-    {
-        if (target == null)
-        {
-            throw new ArgumentNullException(nameof(target));
-        }
+	public static void SetPropertyValue(object target, string propertyPath, object value)
+	{
+		if (target == null)
+		{
+			throw new ArgumentNullException(nameof(target));
+		}
 
-        if (string.IsNullOrWhiteSpace(propertyPath))
-        {
-            throw new ArgumentException("Property path cannot be empty.", nameof(propertyPath));
-        }
+		if (string.IsNullOrWhiteSpace(propertyPath))
+		{
+			throw new ArgumentException("Property path cannot be empty.", nameof(propertyPath));
+		}
 
-        var properties = propertyPath.Split('.');
-        var currentObject = target;
+		var properties = propertyPath.Split('.');
+		var currentObject = target;
 
-        for (var i = 0; i < properties.Length - 1; i++)
-        {
-            currentObject = GetObjectOrIndexedValue(currentObject, properties[i]);
-        }
+		for (var i = 0; i < properties.Length - 1; i++)
+		{
+			currentObject = GetObjectOrIndexedValue(currentObject, properties[i]);
+		}
 
-        if (currentObject == null)
-        {
-            return;
-        }
+		if (currentObject == null)
+		{
+			return;
+		}
 
-        var propName = properties[^1];
+		var propName = properties[^1];
 
-        if (string.IsNullOrWhiteSpace(propName))
-        {
-            throw new InvalidOperationException("Wrong property path");
-        }
+		if (string.IsNullOrWhiteSpace(propName))
+		{
+			throw new InvalidOperationException("Wrong property path");
+		}
 
-        if (propName.Contains('['))
-        {
-            throw new NotSupportedException();
-        }
+		if (propName.Contains('['))
+		{
+			throw new NotSupportedException();
+		}
 
-        var propertyInfo = currentObject.GetType().GetProperty(propName);
-        if (propertyInfo == null)
-        {
-            return;
-        }
+		var propertyInfo = currentObject.GetType().GetProperty(propName);
+		if (propertyInfo == null)
+		{
+			return;
+		}
 
-        var converter = TypeDescriptor.GetConverter(propertyInfo.PropertyType);
-        var convertedValue = value == null || value.GetType() == propertyInfo.PropertyType
-            ? value
-            : converter.ConvertFrom(value);
+		var converter = TypeDescriptor.GetConverter(propertyInfo.PropertyType);
+		var convertedValue = value == null || value.GetType() == propertyInfo.PropertyType
+			? value
+			: converter.ConvertFrom(value);
 
-        propertyInfo.SetValue(currentObject, convertedValue);
-    }
+		propertyInfo.SetValue(currentObject, convertedValue);
+	}
 
-    public static (object Value, Action<object> Setter)? GetPropertySetter(object target, string propertyPath, object value)
-    {
-        if (target == null)
-        {
-            throw new ArgumentNullException(nameof(target));
-        }
+	public static (object Value, Action<object> Setter)? GetPropertySetter(object target, string propertyPath, object value)
+	{
+		if (target == null)
+		{
+			throw new ArgumentNullException(nameof(target));
+		}
 
-        if (string.IsNullOrWhiteSpace(propertyPath))
-        {
-            throw new ArgumentException("Property path cannot be empty.", nameof(propertyPath));
-        }
+		if (string.IsNullOrWhiteSpace(propertyPath))
+		{
+			throw new ArgumentException("Property path cannot be empty.", nameof(propertyPath));
+		}
 
-        var properties = propertyPath.Split('.');
-        var currentObject = target;
+		var properties = propertyPath.Split('.');
+		var currentObject = target;
 
-        for (var i = 0; i < properties.Length - 1; i++)
-        {
-            currentObject = GetObjectOrIndexedValue(currentObject, properties[i]);
-        }
+		for (var i = 0; i < properties.Length - 1; i++)
+		{
+			currentObject = GetObjectOrIndexedValue(currentObject, properties[i]);
+		}
 
-        return SetValueOnObject(currentObject, properties[^1], value);
-    }
+		return SetValueOnObject(currentObject, properties[^1], value);
+	}
 
-    private static object GetObjectOrIndexedValue(object obj, string propName)
-    {
-        if (obj == null)
-        {
-            return null;
-        }
+	private static object GetObjectOrIndexedValue(object obj, string propName)
+	{
+		if (obj == null)
+		{
+			return null;
+		}
 
-        if (string.IsNullOrWhiteSpace(propName))
-        {
-            throw new InvalidOperationException("Wrong property path");
-        }
+		if (string.IsNullOrWhiteSpace(propName))
+		{
+			throw new InvalidOperationException("Wrong property path");
+		}
 
-        return propName.Contains('[')
-            ? GetIndexedValue(obj, propName)
-            : obj.GetType().GetProperty(propName)?.GetValue(obj);
-    }
+		return propName.Contains('[')
+			? GetIndexedValue(obj, propName)
+			: obj.GetType().GetProperty(propName)?.GetValue(obj);
+	}
 
-    private static object GetIndexedValue(object obj, string propName)
-    {
-        if (obj == null)
-        {
-            return null;
-        }
+	private static object GetIndexedValue(object obj, string propName)
+	{
+		if (obj == null)
+		{
+			return null;
+		}
 
-        var (index, cleanedPropName) = GetIndexAndCleanedPropertyName(propName);
-        var propertyInfo = obj.GetType().GetProperty(cleanedPropName);
+		var (index, cleanedPropName) = GetIndexAndCleanedPropertyName(propName);
+		var propertyInfo = obj.GetType().GetProperty(cleanedPropName);
 
-        if (propertyInfo == null)
-        {
-            return null;
-        }
+		if (propertyInfo == null)
+		{
+			return null;
+		}
 
-        var value = propertyInfo.GetValue(obj);
+		var value = propertyInfo.GetValue(obj);
 
-        if (value == null)
-        {
-            return null;
-        }
+		if (value == null)
+		{
+			return null;
+		}
 
-        if (propertyInfo.PropertyType.IsArray)
-        {
-            return value is Array array && index < array.Length
-                ? array.GetValue(index)
-                : throw new InvalidOperationException("Wrong value type");
-        }
+		if (propertyInfo.PropertyType.IsArray)
+		{
+			return value is Array array && index < array.Length
+				? array.GetValue(index)
+				: throw new InvalidOperationException("Wrong value type");
+		}
 
-        if (typeof(IList).IsAssignableFrom(propertyInfo.PropertyType))
-        {
-            return value is IList list && index < list.Count
-                ? list[index]
-                : throw new InvalidOperationException("Wrong value type");
-        }
+		if (typeof(IList).IsAssignableFrom(propertyInfo.PropertyType))
+		{
+			return value is IList list && index < list.Count
+				? list[index]
+				: throw new InvalidOperationException("Wrong value type");
+		}
 
-        throw new InvalidOperationException("Wrong indexer property");
-    }
+		throw new InvalidOperationException("Wrong indexer property");
+	}
 
-    private static (int, string) GetIndexAndCleanedPropertyName(string propName)
-    {
-        var iteratorStart = propName.IndexOf('[');
-        var iteratorEnd = propName.IndexOf(']');
-        var iteratorValue = propName.Substring(iteratorStart + 1, iteratorEnd - iteratorStart - 1);
-        var cleanedPropName = propName[..iteratorStart];
-        return (Convert.ToInt32(iteratorValue), cleanedPropName);
-    }
+	private static (int, string) GetIndexAndCleanedPropertyName(string propName)
+	{
+		var iteratorStart = propName.IndexOf('[');
+		var iteratorEnd = propName.IndexOf(']');
+		var iteratorValue = propName.Substring(iteratorStart + 1, iteratorEnd - iteratorStart - 1);
+		var cleanedPropName = propName[..iteratorStart];
+		return (Convert.ToInt32(iteratorValue), cleanedPropName);
+	}
 
-    private static (object, Action<object>)? SetValueOnObject(object obj, string propName, object valueToSet)
-    {
-        if (obj == null)
-        {
-            return null;
-        }
+	private static (object, Action<object>)? SetValueOnObject(object obj, string propName, object valueToSet)
+	{
+		if (obj == null)
+		{
+			return null;
+		}
 
-        if (string.IsNullOrWhiteSpace(propName))
-        {
-            throw new InvalidOperationException("Wrong property path");
-        }
+		if (string.IsNullOrWhiteSpace(propName))
+		{
+			throw new InvalidOperationException("Wrong property path");
+		}
 
-        if (propName.Contains('['))
-        {
-            return SetIndexedValue(obj, propName, valueToSet);
-        }
+		if (propName.Contains('['))
+		{
+			return SetIndexedValue(obj, propName, valueToSet);
+		}
 
-        var propertyInfo = obj.GetType().GetProperty(propName);
-        if (propertyInfo == null)
-        {
-            return null;
-        }
+		var propertyInfo = obj.GetType().GetProperty(propName);
+		if (propertyInfo == null)
+		{
+			return null;
+		}
 
-        var convertedValue = ConvertValue(valueToSet, propertyInfo.PropertyType);
-        propertyInfo.SetValue(obj, convertedValue);
-        return (convertedValue, val => propertyInfo.SetValue(obj, val));
-    }
+		var convertedValue = ConvertValue(valueToSet, propertyInfo.PropertyType);
+		propertyInfo.SetValue(obj, convertedValue);
+		return (convertedValue, val => propertyInfo.SetValue(obj, val));
+	}
 
-    private static (object, Action<object>)? SetIndexedValue(object obj, string propName, object valueToSet)
-    {
-        var (index, cleanedPropName) = GetIndexAndCleanedPropertyName(propName);
-        var propertyInfo = obj.GetType().GetProperty(cleanedPropName);
-        var convertedValue = ConvertValue(valueToSet, propertyInfo!.PropertyType);
+	private static (object, Action<object>)? SetIndexedValue(object obj, string propName, object valueToSet)
+	{
+		var (index, cleanedPropName) = GetIndexAndCleanedPropertyName(propName);
+		var propertyInfo = obj.GetType().GetProperty(cleanedPropName);
+		var convertedValue = ConvertValue(valueToSet, propertyInfo!.PropertyType);
 
-        var value = propertyInfo.GetValue(obj);
+		var value = propertyInfo.GetValue(obj);
 
-        if (value == null)
-        {
-            throw new InvalidOperationException("Cannot set value to null");
-        }
+		if (value == null)
+		{
+			throw new InvalidOperationException("Cannot set value to null");
+		}
 
-        if (propertyInfo.PropertyType.IsArray)
-        {
-            if (value is not Array array)
-            {
-                throw new InvalidOperationException("Wrong type");
-            }
+		if (propertyInfo.PropertyType.IsArray)
+		{
+			if (value is not Array array)
+			{
+				throw new InvalidOperationException("Wrong type");
+			}
 
-            return (convertedValue, val => array.SetValue(val, index));
-        }
+			return (convertedValue, val => array.SetValue(val, index));
+		}
 
-        if (typeof(IList).IsAssignableFrom(propertyInfo.PropertyType))
-        {
-            if (value is not IList list)
-            {
-                throw new InvalidOperationException("Wrong type");
-            }
+		if (typeof(IList).IsAssignableFrom(propertyInfo.PropertyType))
+		{
+			if (value is not IList list)
+			{
+				throw new InvalidOperationException("Wrong type");
+			}
 
-            return (convertedValue, val => list[index] = val);
-        }
+			return (convertedValue, val => list[index] = val);
+		}
 
-        throw new InvalidOperationException($"Indexed access for property '{cleanedPropName}' is not supported.");
-    }
+		throw new InvalidOperationException($"Indexed access for property '{cleanedPropName}' is not supported.");
+	}
 
-    private static object ConvertValue(object valueToConvert, Type destinationType)
-    {
-        if (valueToConvert is not StringValues stringValues)
-        {
-            return valueToConvert;
-        }
-        
-        if (typeof(IFormFile).IsAssignableFrom(destinationType) && StringValues.IsNullOrEmpty(stringValues))
-        {
-            return null;
-        }
+	private static object ConvertValue(object valueToConvert, Type destinationType)
+	{
+		if (valueToConvert is not StringValues stringValues)
+		{
+			return valueToConvert;
+		}
 
-        var converter = TypeDescriptor.GetConverter(destinationType!);
-   
-        if (!converter.CanConvertFrom(typeof(string)))
-        {
-            throw new InvalidOperationException($"Cannot convert StringValues to '{destinationType}'.");
-        }
+		if (typeof(IFormFile).IsAssignableFrom(destinationType) && StringValues.IsNullOrEmpty(stringValues))
+		{
+			return null;
+		}
 
-        if (!destinationType.IsArray || stringValues is { Count: <= 1 })
-        {
-            try
-            {
-                return converter.ConvertFromString(valueToConvert.ToString());
-            }
-            catch
-            {
-                return Activator.CreateInstance(destinationType);
-            }
-        }
+		var converter = TypeDescriptor.GetConverter(destinationType!);
 
-        var elementType = destinationType.GetElementType();
-        var array = Array.CreateInstance(elementType, stringValues.Count);
-        for (var i = 0; i < stringValues.Count; i++)
-        {
-            try
-            {
-                array.SetValue(converter.ConvertFromString(stringValues[i]), i);
-            }
-            catch
-            {
-                array.SetValue(Activator.CreateInstance(elementType), i);
-            }
-        }
+		if (!converter.CanConvertFrom(typeof(string)))
+		{
+			throw new InvalidOperationException($"Cannot convert StringValues to '{destinationType}'.");
+		}
 
-        return array;
-    }
+		if (!destinationType.IsArray || stringValues is { Count: <= 1 })
+		{
+			try
+			{
+				return converter.ConvertFromString(valueToConvert.ToString());
+			}
+			catch
+			{
+				return Activator.CreateInstance(destinationType);
+			}
+		}
+
+		var elementType = destinationType.GetElementType();
+		var array = Array.CreateInstance(elementType, stringValues.Count);
+		for (var i = 0; i < stringValues.Count; i++)
+		{
+			try
+			{
+				array.SetValue(converter.ConvertFromString(stringValues[i]), i);
+			}
+			catch
+			{
+				array.SetValue(Activator.CreateInstance(elementType), i);
+			}
+		}
+
+		return array;
+	}
 }

--- a/src/Scripts/hydro.js
+++ b/src/Scripts/hydro.js
@@ -54,6 +54,11 @@
         if (push) {
           history.pushState({}, '', url);
         }
+
+        document.dispatchEvent(new CustomEvent('HydroLocation', {
+                detail: { url, selector, push, payload }
+            }));
+
       }
     } catch (error) {
       if (error.message === 'Request stopped') {
@@ -212,6 +217,7 @@
 
     const component = el.closest("[hydro]");
     const componentId = component.getAttribute("id");
+    const componentName = component.getAttribute("hydro-name");
 
     if (!component) {
       throw new Erorr('Cannot determine the closest Hydro component');
@@ -374,6 +380,10 @@
                 counter++;
               }
             });
+
+            document.dispatchEvent(new CustomEvent('HydroUpdate', {
+                detail: { componentId, componentName, url, type }
+            }));
           }
 
           const locationHeader = response.headers.get('Hydro-Location');
@@ -386,6 +396,10 @@
           const redirectHeader = response.headers.get('Hydro-Redirect');
           if (redirectHeader) {
             window.location.href = redirectHeader;
+
+            document.dispatchEvent(new CustomEvent('HydroRedirect', {
+                detail: { redirectHeader }
+            }));
           }
 
           setTimeout(() => { // make sure the event handlers got registered
@@ -666,6 +680,9 @@ document.addEventListener('alpine:init', () => {
       $component: null,
       init() {
         this.$component = window.Hydro.findComponent(this.$el);
+        document.dispatchEvent(new CustomEvent('HydroComponentInit', {
+            detail: { component: this.$component }
+        }));
       },
       async invoke(e, action) {
         if (["click", "submit"].includes(e.type) && ['A', 'BUTTON', 'FORM'].includes(this.$el.tagName)) {

--- a/src/Scripts/hydro.js
+++ b/src/Scripts/hydro.js
@@ -43,16 +43,16 @@
         let newTitle = doc.querySelector('head>title');
         element.innerHTML = newContent.innerHTML;
 
-        if (selector === 'body') {
-          window.scrollTo(0, 0);
-        }
-
         if (newTitle) {
           document.title = newTitle.textContent;
         }
 
         if (push) {
           history.pushState({}, '', url);
+        }
+
+        if (selector === 'body' && !window.location.hash) {
+            window.scrollTo(0, 0);
         }
 
         document.dispatchEvent(new CustomEvent('HydroLocation', {

--- a/src/Scripts/hydro.js
+++ b/src/Scripts/hydro.js
@@ -102,9 +102,20 @@ function injectScript(componentElement, scriptContent) {
           history.pushState({}, '', url);
         }
 
-        if (selector === findLocationTarget() && !window.location.hash) {
-            window.scrollTo(0, 0);
-        }
+          if (selector === findLocationTarget() && !window.location.hash) {
+              window.scrollTo(0, 0);
+          }
+          else {
+            
+                const element = document.querySelector(window.location.hash);              
+                 if (element) {
+                    element.scrollIntoView({
+                        behavior: 'smooth', 
+                        block: 'start'  
+                    });
+                }
+
+            }
  
         //exec scripts loaded along with new ajax-loaded content
         execProperScripts(element);

--- a/src/Scripts/hydro.js
+++ b/src/Scripts/hydro.js
@@ -4,6 +4,18 @@
   const configMeta = document.querySelector('meta[name="hydro-config"]');
   const config = configMeta ? JSON.parse(configMeta.content) : {};
 
+    function evalScripts(element) {
+        //eval all non-hydro scripts
+         const scripts = element.querySelectorAll('script:not([type]), script[type="text/javascript"]'); 
+                scripts.forEach(script => {
+                    try {
+                        eval(script.innerHTML);
+                    } catch (e) {
+                        console.error('Error executing script:', e, script.innerHTML);
+                    }
+                });
+    }
+
   async function loadPageContent(url, selector, push, condition, payload) {
     const element = document.querySelector(selector);
     element.classList.add('hydro-loading');
@@ -54,6 +66,9 @@
         if (selector === 'body' && !window.location.hash) {
             window.scrollTo(0, 0);
         }
+ 
+        //eval all non-hydro scripts loaded along with new body content
+        evalScripts(element);
 
         document.dispatchEvent(new CustomEvent('HydroLocation', {
                 detail: { url, selector, push, payload }
@@ -396,6 +411,9 @@ function postProcessHeaders(headers) {
             });
 
             postProcessHeaders(response.headers);
+
+            //eval all non-hydro scripts loaded along with new content
+            evalScripts(component);
 
             document.dispatchEvent(new CustomEvent('HydroComponentUpdate', {
                 detail: { componentId, componentName, url, type }

--- a/src/Services/CookiesManager.cs
+++ b/src/Services/CookiesManager.cs
@@ -1,0 +1,205 @@
+﻿using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace Hydro.Services
+{
+
+    /// <summary>
+    /// Allows to store/read complex objects in cookies
+    /// </summary>
+    public interface ICookieManager
+    {
+        /// <summary>
+        /// Returns a value type or a specific class stored in cookies.
+        /// If cookie was previously saved as `secure` or  you need to decrypt it by setting this method `secure` parameter also to `true`.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="secure"></param>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public T Get<T>(string key, bool secure = false, T defaultValue = default);
+
+        /// <summary>
+        /// Stores in cookies a value type or a specific class. If `secure` parameter is `true` will also be encrypted.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="secure"></param>
+        /// <param name="expires"></param>
+        public void Set<T>(string key, T value, bool secure = false, TimeSpan? expires = null);
+
+        /// <summary>
+        /// Stores in cookies a value type or a specific class with exact options to be used. Will also be encrypted is `Secure` is enabled in options.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="options"></param>
+        public void Set<T>(string key, T value, CookieOptions options);
+
+        /// <summary>
+        /// Deletes a cookie record
+        /// </summary>
+        /// <param name="key"></param>
+        public void Delete(string key);
+    }
+
+    /// <summary>
+    /// Provides a standard implementation for ICookieManager interface, allowing to store/read complex objects in cookies
+    /// </summary>
+    public class CookieManager : ICookieManager
+    {
+
+        /// <summary>
+        /// Primary constructor
+        /// </summary>
+        /// <param name="httpContextAccessor"></param>
+        /// <param name="dataProtectionProvider"></param>
+        public CookieManager(IHttpContextAccessor httpContextAccessor,
+            IDataProtectionProvider dataProtectionProvider)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _dataProtectionProvider = dataProtectionProvider;
+        }
+
+        /// <summary>
+        /// Caching protectors for quick access
+        /// </summary>
+        protected Dictionary<Type, IDataProtector> CachedProtectors = new();
+
+        /// <summary>
+        /// Returns cached protector for a specified type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public virtual IDataProtector GetProtector<T>(T value)
+        {
+            CachedProtectors.TryGetValue(typeof(T), out var protector);
+            if (protector == null)
+            {
+                protector = _dataProtectionProvider.CreateProtector(typeof(T).Name);
+                CachedProtectors.TryAdd(typeof(T), protector);
+            }
+            return protector;
+        }
+
+        /// <summary>
+        /// Returns a value type or a specific class stored in cookies
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="secure"></param>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public T Get<T>(string key, bool secure = false, T defaultValue = default)
+        {
+            try
+            {
+                _httpContextAccessor.HttpContext!.Request.Cookies.TryGetValue(key, out var storage);
+                if (storage != null)
+                {
+                    if (secure)
+                    {
+                        return JsonConvert.DeserializeObject<T>(GetProtector(defaultValue).Unprotect(storage));
+                    }
+                    return JsonConvert.DeserializeObject<T>(storage);
+                }
+            }
+            catch
+            {
+                //ignored
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Customizable default time to be used when `expires` parameter is omitted upon calling the `Set` method. Default is 30 days.
+        /// </summary>
+        public static TimeSpan ExpiresDefault = TimeSpan.FromDays(30);
+
+        /// <summary>
+        /// Whether it will use data protection for secure cookies. You might sometimes want to turn this off for debugging purposes to inspect browser storage.
+        /// </summary>
+        public static bool UseDataProtection = true;
+
+        /// <summary>
+        /// Customizable default JsonSerializerSettings used for complex objects
+        /// </summary>
+        public static JsonSerializerSettings JsonSettings = new()
+        {
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+        };
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IDataProtectionProvider _dataProtectionProvider;
+
+        /// <summary>
+        /// Stores in cookies a value type or a specific class. If `secure` parameter is `true` will also be encrypted.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="secure"></param>
+        /// <param name="expires"></param>
+        public void Set<T>(string key, T value, bool secure = false, TimeSpan? expires = null)
+        {
+            if (expires == null)
+            {
+                expires = ExpiresDefault;
+            }
+
+            var options = new CookieOptions
+            {
+                Secure = secure,
+                MaxAge = expires.Value
+            };
+
+            Set(key, value, options);
+        }
+
+        /// <summary>
+        /// Stores in cookies a value type or a specific class with exact options to be used. Will also be encrypted is `Secure` is enabled in options.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="options"></param>
+        public void Set<T>(string key, T value, CookieOptions options)
+        {
+            var response = _httpContextAccessor.HttpContext!.Response;
+
+            if (value != null)
+            {
+                string serializeObject;
+                if (options.Secure && UseDataProtection)
+                {
+                    serializeObject = GetProtector(value).Protect(JsonConvert.SerializeObject(value));
+                }
+                else
+                {
+                    serializeObject = JsonConvert.SerializeObject(value, JsonSettings);
+                }
+                response.Cookies.Append(key, serializeObject, options);
+            }
+            else
+            {
+                response.Cookies.Delete(key);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a cookie record
+        /// </summary>
+        /// <param name="key"></param>
+        public void Delete(string key)
+        {
+            var response = _httpContextAccessor.HttpContext!.Response;
+            response.Cookies.Delete(key);
+        }
+    }
+}


### PR DESCRIPTION
Some changes to browse

1. General:
* added .net8 framework to build along with .net6 version, csproj: 
`<TargetFrameworks>net6.0;net8.0</TargetFrameworks>`

2. HydroComponent + hydro.js:

* added support for custom json serialization settings everywhere, default settings are loop-reference proof now.
```csharp
    public static JsonSerializerSettings JsonSerializerSettings = new()
    {
        Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
    };
```

* Again fixed scroll to anchors after async load, the previous pr-fix was effective in half cases only. inside hydro.js.

```js

 if (push) {
   history.pushState({}, '', url);
 }

   if (selector === findLocationTarget() && !window.location.hash) {
       window.scrollTo(0, 0);
   }
   else {
     
         const element = document.querySelector(window.location.hash);              
          if (element) {
             element.scrollIntoView({
                 behavior: 'smooth', 
                 block: 'start'  
             });
         }

     }
```

* `public void ExecuteJs(string script)` method to invoke js from code behind. Will be executed after the dom is fully rendered. Might consider making it virtual. 

Here hydro.js processes scripts in 2 ways, for static content scripts are present inside the HTML inside custom tags and for dynamic async content they are present inside headers (potential size-limit problem?).  Then scripts are injected like this to be executed by browser:

```js
function injectScript(componentElement, scriptContent) {
  const script = document.createElement('script');
  script.type = 'text/javascript';
  script.innerHTML = `
    (function($component) {
      ${scriptContent}
    })(document.getElementById("${componentElement.id}"));
  `;
  script.setAttribute('data-injected', 'true');
  componentElement.appendChild(script);
}
```

* Execute JS scripts that are included inside components HTML and were not executed in case of ajax-async-loading. Will be executed after the dom is fully rendered.

Present `<script>` elements will never be executed by browser after async loads, so they are removed and at the same location hydro.js creates new script elements.

```js
  function injectScriptAtSamePosition(existingScript) {
    const newScript = document.createElement('script');
    newScript.type = 'text/javascript';
    newScript.innerHTML = existingScript.innerHTML;
    newScript.setAttribute('data-injected', 'true');
    existingScript.parentNode.replaceChild(newScript, existingScript);
}
```

* Added native events that are invoked by hydro.js to easily debug and plug-in your JS code:

example of subscribing to:

```js
document.addEventListener('HydroLocation', function (event) {
            
        const { url, headers, selector, push, payload } = event.detail;
            
        console.log("HydroLocation:", event.detail);

        initControls();

    });

document.addEventListener('HydroComponentUpdate', function (event) {

    const { componentId, name, url, type } = event.detail;
            
    console.log("HydroComponentUpdate: ", event.detail);

    //if (name == "KbDisplayComponent") {
    //    scrollToTop();
    //}

});

document.addEventListener('HydroRedirect', function (event) {

    const { url } = event.detail;
            
    console.log("HydroRedirect: ", event.detail);

    mainMenu();
});

document.addEventListener('HydroComponentInit', function (event) {

    const { component } = event.detail;
            
    console.log("HydroComponentInit: ", event.detail);

});

```

* `With ExecuteJs` we can now do the following. This is NOT in the PR but IMHO should take it's place inside the hydro core.

Example: you have finished editing something and you want to update a specific component to reflect the changes. From component A just call `ExecuteJs("updateComponent('ComponentB')");`

pick up inside JS:

```js
//hacky update for ANY component. could make a clean method.
async function updateComponent(findName) {
    let element = document.querySelector('[hydro-name="'+findName+'"]');
    await window.Hydro.hydroAction(element, window.Hydro.findComponent(element), { name: "Mount"});
}

```
If this goes into core we then could add another native event `HydroNeedUpdate`, could be subscribed to as follows:

```js
document.addEventListener('HydroNeedUpdate', function (event) {
    const { name } = event.detail;            
    console.log("HydroNeedUpdate: ", event.detail);

//an update was ordered for a specific component
  
});

```


* Added some blazor-friendly virtual methods to favor porting blazor code more easily to hydro. 

`virtual Task OnAfterRenderAsync(bool firstRender)`
`protected virtual Task OnParametersSetAsync()`
`protected virtual bool ShouldRender()`

* added ICookieManager for fluent cookies management

* added customization to Location that would be replaced after async load, ability to have _Layout=null and for a faster async loading of updated components

Example: 
1. In your _Laout replace `@RenderBody()` with `@Html.HydroBody(RenderBody())`. Why so that hydro can automatically recognize this location and insert all async loaded HTML here instead of replacing the whole `<body>`.
2. Inside your _ViewStart.cshtml replace `Layout = "_Layout";` with
```csharp
@using Hydro
@{
    Layout = Context.IsHydroBoosted() ? null : "_Layout";
}
```
Now you are all set for faster component rendering avoiding to render the layout for ajax async calls.
At the same time notice an additional method `public void Location(string url, string target, object payload = null)` where `target` can be anything, "#mybody", ".wrapper" etc.

* Ability to POST a `<form>` and validate/read inside the action:

```csharp
        public async Task Submit()
        {
            //can read form fields manually
            var email = this.Request.Form["Data.Email"];

           //method to auto-read, returns value of ModelState.IsValid
           var isValid = await BindFormAndValidateAsync(Data, (model, modelState) =>
           {
               //optional code to transform received fields before they go to validation
               if (model.Name != null)
                   model.Name = model.Name.ToPhraseCase().Trim();
        
               //can check email is unique
               if (!EmailValidator.IsValidEmail(model.Email))
               {
                   modelState.AddModelError("Email", "Email taken");
               }
           });

            if (isValid)
            {
                Error=""; //displayed in UI

                try
                {
                    //can read posted files too
                    if (Request.Form.Files.Count > 0)
                    {
                        var savedAs = await SaveAttachmentFile("avatar");
                        if (!string.IsNullOrEmpty(savedAs))
                        {
                            Data.AvatarPath = savedAs;
                        }
                    }
                    
                     ...
                  
                }
                catch (Exception e)
                {
                    Console.WriteLine(e);
                    this.Error = e.Message;
                }
            }
            else
            {
                var errors = ModelState.Values
                .SelectMany(v => v.Errors)
                .Select(e => e.ErrorMessage)
                .ToList();

                Error = errors.ToTags(", ");
            }
        }
```

some points inside hydro.js:

```js
//inside enqueueHydroPromise
    // NEW post form from eventData
    if (eventData instanceof HTMLFormElement) {
    new FormData(eventData).forEach((value, key) => {
        requestForm.append(key, value);
    });
```

```js
  Alpine.data('hydro', () => {

      ...

      async invoke(e, action) {
        if (["click", "submit"].includes(e.type) && ['A', 'BUTTON', 'FORM'].includes(this.$el.tagName)) {
          e.preventDefault();
        }
        await window.Hydro.hydroAction(this.$el, this.$component, action);
      },
      async postForm(e, action) {  // this will be called by code from HydroOnTagHelper->GetJsPostFormExpression
        if (["click", "submit"].includes(e.type) && ['A', 'BUTTON', 'FORM'].includes(this.$el.tagName)) {
          e.preventDefault();
        }
        await window.Hydro.hydroAction(this.$el, this.$component, action, e.target);
      },
```
