### PR TITLE
Migrate from Newtonsoft to System.Text.Json

### DIFF
--- a/src/Configuration/HydroOptions.cs
+++ b/src/Configuration/HydroOptions.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro.Configuration;
 
@@ -20,7 +20,7 @@ public class HydroOptions
     /// <summary>
     /// Serializer settings
     /// </summary>
-    public JsonSerializerSettings JsonSerializerSettings => HydroComponent.JsonSerializerSettings;
+    public JsonSerializerOptions JsonSerializerSettings => HydroComponent.JsonSerializerSettings;
     
     /// <summary>
     /// Indicates if antiforgery token should be exchanged during the communication

--- a/src/Hydro.csproj
+++ b/src/Hydro.csproj
@@ -19,12 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.50"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.50" />
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -41,6 +40,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/HydroComponent.cs
+++ b/src/HydroComponent.cs
@@ -4,6 +4,8 @@ using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using HtmlAgilityPack;
 using Hydro.Configuration;
 using Hydro.Services;
@@ -20,7 +22,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
 using Int32Converter = Hydro.Utils.Int32Converter;
 
 namespace Hydro;
@@ -48,10 +49,10 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
     private static readonly MethodInfo InvokeActionMethod = typeof(HydroComponent).GetMethod(nameof(InvokeAction), BindingFlags.Static | BindingFlags.NonPublic);
     private static readonly MethodInfo InvokeActionAsyncMethod = typeof(HydroComponent).GetMethod(nameof(InvokeActionAsync), BindingFlags.Static | BindingFlags.NonPublic);
 
-    internal static readonly JsonSerializerSettings JsonSerializerSettings = new()
+    internal static readonly JsonSerializerOptions JsonSerializerSettings = new()
     {
-        Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+        Converters = { new Int32Converter() },
+        ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles
     };
 
     private static readonly ConcurrentDictionary<Type, IHydroAuthorizationFilter[]> ComponentAuthorizationAttributes = new();
@@ -68,13 +69,13 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
     /// <summary>
     /// Provides component's key value
     /// </summary>
-    [JsonProperty]
+    [JsonPropertyName(nameof(Key))]
     public string Key { get; set; }
 
     /// <summary>
     /// Component's HTML behavior when the key changes
     /// </summary>
-    [JsonProperty]
+    [JsonPropertyName(nameof(KeyBehavior))]
     public KeyBehavior KeyBehavior { get; set; }
 
     /// <summary>
@@ -810,7 +811,7 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
         scriptNode.SetAttributeValue("type", "text/hydro");
         scriptNode.SetAttributeValue("hydro-event", "true");
         scriptNode.SetAttributeValue("x-data", "");
-        scriptNode.SetAttributeValue("x-on-hydro-event", JsonConvert.SerializeObject(eventData, JsonSerializerSettings));
+        scriptNode.SetAttributeValue("x-on-hydro-event", JsonSerializer.Serialize(eventData, JsonSerializerSettings));
         return scriptNode;
     }
 
@@ -855,7 +856,7 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
             })
             .ToList();
 
-        return JsonConvert.SerializeObject(data, JsonSerializerSettings);
+        return JsonSerializer.Serialize(data, JsonSerializerSettings);
     }
 
     private void PopulateClientScripts()
@@ -975,7 +976,7 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
     /// <returns>Payload</returns>
     public T GetPayload<T>() =>
         HttpContext.Request.Headers.TryGetValue(HydroConsts.RequestHeaders.Payload, out var payloadString)
-            ? JsonConvert.DeserializeObject<T>(payloadString)
+            ? JsonSerializer.Deserialize<T>(payloadString)
             : default;
 
     private async Task TriggerEvent()
@@ -1036,7 +1037,7 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
         if (HttpContext.Items.TryGetValue(HydroConsts.ContextItems.BaseModel, out var baseModel))
         {
             var unprotect = persistentState.Decompress((string)baseModel);
-            JsonConvert.PopulateObject(unprotect, this);
+            JsonPopulator.PopulateObject(unprotect, this);
         }
     }
 
@@ -1140,8 +1141,8 @@ public abstract class HydroComponent : TagHelper, IViewContextAware
             {
                 try
                 {
-                    var json = JsonConvert.SerializeObject(sourceProperty.GetValue(source), JsonSerializerSettings);
-                    sourceValue = JsonConvert.DeserializeObject(json, targetProperty.PropertyType);
+                    var json = JsonSerializer.Serialize(sourceProperty.GetValue(source), JsonSerializerSettings);
+                    sourceValue = JsonSerializer.Deserialize(json, targetProperty.PropertyType, JsonSerializerSettings);
                 }
                 catch
                 {

--- a/src/HydroComponentsExtensions.cs
+++ b/src/HydroComponentsExtensions.cs
@@ -10,11 +10,19 @@ using Hydro.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
+using Hydro.Utils;
 
 namespace Hydro;
 
 internal static class HydroComponentsExtensions
 {
+    private static readonly JsonSerializerOptions _deserializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new Int32Converter() },
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
+    };
+
     public static void MapHydroComponent(this IEndpointRouteBuilder app, Type componentType)
     {
         
@@ -65,6 +73,7 @@ internal static class HydroComponentsExtensions
 
     private static async Task ExecuteRequestOperations(HttpContext context, string method)
     {
+
         if (!context.Request.HasFormContentType)
         {
             throw new InvalidOperationException("Hydro form doesn't contain form which is required");
@@ -78,9 +87,9 @@ internal static class HydroComponentsExtensions
 
         var model = hydroData["__hydro_model"].First();
         var type = hydroData["__hydro_type"].First();
-        var parameters = JsonSerializer.Deserialize<Dictionary<string, object>>(hydroData["__hydro_parameters"].FirstOrDefault("{}"), HydroComponent.JsonSerializerSettings);
-        var eventData = JsonSerializer.Deserialize<HydroEventPayload>(hydroData["__hydro_event"].FirstOrDefault("null"));
-        var componentIds = JsonSerializer.Deserialize<string[]>(hydroData["__hydro_componentIds"].FirstOrDefault("[]"));
+        var parameters = JsonSerializer.Deserialize<Dictionary<string, object>>(hydroData["__hydro_parameters"].FirstOrDefault("{}"), _deserializerOptions);
+        var eventData = JsonSerializer.Deserialize<HydroEventPayload>(hydroData["__hydro_event"].FirstOrDefault("null"), _deserializerOptions);
+        var componentIds = JsonSerializer.Deserialize<string[]>(hydroData["__hydro_componentIds"].FirstOrDefault("[]"), _deserializerOptions);
         var form = new FormCollection(formValues, hydroData.Files);
 
         context.Items.Add(HydroConsts.ContextItems.RenderedComponentIds, componentIds);
@@ -90,7 +99,7 @@ internal static class HydroComponentsExtensions
         if (eventData != null)
         {
             context.Items.Add(HydroConsts.ContextItems.EventName, eventData.Name);
-            context.Items.Add(HydroConsts.ContextItems.EventData, eventData.Data);
+            context.Items.Add(HydroConsts.ContextItems.EventData, eventData.Data.ToString());
             context.Items.Add(HydroConsts.ContextItems.EventSubject, eventData.Subject);
         }
 

--- a/src/HydroComponentsExtensions.cs
+++ b/src/HydroComponentsExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Routing;
 using Hydro.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro;
 
@@ -78,9 +78,9 @@ internal static class HydroComponentsExtensions
 
         var model = hydroData["__hydro_model"].First();
         var type = hydroData["__hydro_type"].First();
-        var parameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(hydroData["__hydro_parameters"].FirstOrDefault("{}"), HydroComponent.JsonSerializerSettings);
-        var eventData = JsonConvert.DeserializeObject<HydroEventPayload>(hydroData["__hydro_event"].FirstOrDefault(string.Empty));
-        var componentIds = JsonConvert.DeserializeObject<string[]>(hydroData["__hydro_componentIds"].FirstOrDefault("[]"));
+        var parameters = JsonSerializer.Deserialize<Dictionary<string, object>>(hydroData["__hydro_parameters"].FirstOrDefault("{}"), HydroComponent.JsonSerializerSettings);
+        var eventData = JsonSerializer.Deserialize<HydroEventPayload>(hydroData["__hydro_event"].FirstOrDefault("null"));
+        var componentIds = JsonSerializer.Deserialize<string[]>(hydroData["__hydro_componentIds"].FirstOrDefault("[]"));
         var form = new FormCollection(formValues, hydroData.Files);
 
         context.Items.Add(HydroConsts.ContextItems.RenderedComponentIds, componentIds);

--- a/src/HydroHttpResponseExtensions.cs
+++ b/src/HydroHttpResponseExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro;
 
@@ -44,6 +44,6 @@ public static class HydroHttpResponseExtensions
             payload
         };
 
-        response.Headers.Append("Hydro-Location", new StringValues(JsonConvert.SerializeObject(data)));
+        response.Headers.Append("Hydro-Location", new StringValues(JsonSerializer.Serialize(data)));
     }
 }

--- a/src/JsonSettings.cs
+++ b/src/JsonSettings.cs
@@ -1,15 +1,17 @@
 using Hydro.Utils;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Hydro;
 
 internal static class JsonSettings
 {
-    public static readonly JsonSerializerSettings SerializerSettings = new()
+    public static readonly JsonSerializerOptions SerializerSettings = new()
     {
-        Converters = new JsonConverter[] { new Int32Converter() }.ToList(),
-        NullValueHandling = NullValueHandling.Ignore,
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        Converters = { new Int32Converter() },
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
     };
 }

--- a/src/PropertyInjector.cs
+++ b/src/PropertyInjector.cs
@@ -1,11 +1,11 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Reflection;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Text.Json;
 
 namespace Hydro;
 
@@ -17,7 +17,7 @@ internal static class PropertyInjector
     public static string SerializeDeclaredProperties(Type type, object instance)
     {
         var regularProperties = GetRegularProperties(type, instance);
-        return JsonConvert.SerializeObject(regularProperties, HydroComponent.JsonSerializerSettings);
+        return JsonSerializer.Serialize(regularProperties, HydroComponent.JsonSerializerSettings);
     }
 
     private static IDictionary<string, object> GetRegularProperties(Type type, object instance) =>

--- a/src/Services/CookieStorage.cs
+++ b/src/Services/CookieStorage.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro.Services;
 
@@ -26,7 +26,7 @@ public class CookieStorage
                     ? _persistentState.Decompress(storage)
                     : storage;
 
-                return JsonConvert.DeserializeObject<T>(json);
+                return JsonSerializer.Deserialize<T>(json, JsonSettings);
             }
         }
         catch
@@ -43,11 +43,11 @@ public class CookieStorage
     public static TimeSpan DefaultExpirationTime = TimeSpan.FromDays(30);
 
     /// <summary>
-    /// Customizable default JsonSerializerSettings used for complex objects
+    /// Customizable default JsonSerializerOptions used for complex objects
     /// </summary>
-    public static JsonSerializerSettings JsonSettings = new()
+    public static JsonSerializerOptions JsonSettings = new()
     {
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+        ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles
     };
 
     internal CookieStorage(HttpContext httpContext, IPersistentState persistentState)
@@ -78,7 +78,7 @@ public class CookieStorage
 
         if (value != null)
         {
-            var serializedValue = JsonConvert.SerializeObject(value, JsonSettings);
+            var serializedValue = JsonSerializer.Serialize(value, JsonSettings);
             var finalValue = encryption
                 ? _persistentState.Compress(serializedValue) 
                 : serializedValue;

--- a/src/TagHelpers/HydroConfigMetaTagHelper.cs
+++ b/src/TagHelpers/HydroConfigMetaTagHelper.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
 using Hydro.Configuration;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro.TagHelpers;
 
@@ -30,7 +30,7 @@ public sealed class HydroConfigMetaTagHelper : TagHelper
     {
         var hydroOptions = ViewContext.HttpContext.RequestServices.GetService<HydroOptions>();
         
-        var config = JsonConvert.SerializeObject(GetConfig(hydroOptions));
+        var config = JsonSerializer.Serialize(GetConfig(hydroOptions), HydroComponent.JsonSerializerSettings);
 
         output.Attributes.RemoveAll("content");
 

--- a/src/TagHelpers/HydroDispatchTagHelper.cs
+++ b/src/TagHelpers/HydroDispatchTagHelper.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro.TagHelpers;
 
@@ -60,7 +60,7 @@ public sealed class HydroDispatchTagHelper : TagHelper
         
         output.Attributes.Add(new(
             "x-hydro-dispatch",
-            new HtmlString(JsonConvert.SerializeObject(data)),
+            new HtmlString(JsonSerializer.Serialize(data, JsonSettings.SerializerSettings)),
             HtmlAttributeValueStyle.SingleQuotes)
         );
         

--- a/src/TagHelpers/HydroOnTagHelper.cs
+++ b/src/TagHelpers/HydroOnTagHelper.cs
@@ -1,10 +1,10 @@
 ﻿using System.Linq.Expressions;
+using System.Text.Json;
 using Hydro.Utils;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Newtonsoft.Json;
 using static Hydro.ExpressionExtensions;
 
 namespace Hydro.TagHelpers;
@@ -153,7 +153,7 @@ public sealed class HydroOnTagHelper : TagHelper
             subject = subject
         };
 
-        var invokeJson = JsonConvert.SerializeObject(invokeData, JsonSettings.SerializerSettings);
+        var invokeJson = JsonSerializer.Serialize(invokeData, JsonSettings.SerializerSettings);
         var invokeJsObject = DecodeJsExpressionsInJson(invokeJson);
 
         return $"dispatch($event, {invokeJsObject})";
@@ -179,7 +179,7 @@ public sealed class HydroOnTagHelper : TagHelper
             return null;
         }
 
-        var invokeJson = JsonConvert.SerializeObject(new
+        var invokeJson = JsonSerializer.Serialize(new
         {
             eventData.Value.Name,
             eventData.Value.Parameters

--- a/src/Utils/Base64Extensions.cs
+++ b/src/Utils/Base64Extensions.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Hydro.Utils;
 
@@ -12,7 +12,7 @@ internal static class Base64
             return null;
         }
 
-        var json = JsonConvert.SerializeObject(input, HydroComponent.JsonSerializerSettings);
+        var json = JsonSerializer.Serialize(input, HydroComponent.JsonSerializerSettings);
         var bytes = Encoding.UTF8.GetBytes(json);
         return Convert.ToBase64String(bytes);
     }
@@ -26,6 +26,6 @@ internal static class Base64
 
         var bytes =  Convert.FromBase64String(input);
         var json = Encoding.UTF8.GetString(bytes);
-        return JsonConvert.DeserializeObject(json, outputType);
+        return JsonSerializer.Deserialize(json, outputType, HydroComponent.JsonSerializerSettings);
     }
 }

--- a/src/Utils/Int32Converter.cs
+++ b/src/Utils/Int32Converter.cs
@@ -1,19 +1,52 @@
-using Newtonsoft.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Hydro.Utils;
 
-internal class Int32Converter : JsonConverter
+internal class Int32Converter : JsonConverter<object>
 {
-    public override bool CanConvert(Type objectType) => 
-        objectType == typeof(int) || objectType == typeof(long) || objectType == typeof(object);
+    // Cacheamos las opciones "sin este converter" para no romper el cache de metadata
+    // de STJ ni reconstruirlas en cada Read/Write.
+    private static readonly ConditionalWeakTable<JsonSerializerOptions, JsonSerializerOptions> _withoutSelfCache = new();
 
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
-        reader.TokenType == JsonToken.Integer
-            ? Convert.ToInt32(reader.Value)
-            : serializer.Deserialize(reader);
+    public override bool CanConvert(Type typeToConvert) =>
+        typeToConvert == typeof(int) || typeToConvert == typeof(long) || typeToConvert == typeof(object);
 
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) =>
-        throw new InvalidOperationException();
-    
-    public override bool CanWrite => false;
+    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var intValue))
+        {
+            return intValue;
+        }
+
+        return JsonSerializer.Deserialize(ref reader, typeToConvert, WithoutSelf(options));
+    }
+
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        // Equivalente a CanWrite => false en Newtonsoft:
+        // no participamos en la escritura, delegamos al serializer por defecto.
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        JsonSerializer.Serialize(writer, value, value.GetType(), WithoutSelf(options));
+    }
+
+    private static JsonSerializerOptions WithoutSelf(JsonSerializerOptions options) =>
+        _withoutSelfCache.GetValue(options, static opts =>
+        {
+            var copy = new JsonSerializerOptions(opts);
+            for (int i = copy.Converters.Count - 1; i >= 0; i--)
+            {
+                if (copy.Converters[i] is Int32Converter)
+                {
+                    copy.Converters.RemoveAt(i);
+                }
+            }
+            return copy;
+        });
 }

--- a/src/Utils/JsonPopulator.cs
+++ b/src/Utils/JsonPopulator.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Hydro.Utils;
+
+internal static class JsonPopulator
+{
+    public static void PopulateObject(string json, object target, JsonSerializerOptions options = null)
+    {
+        if (target is null) throw new ArgumentNullException(nameof(target));
+
+        using var document = JsonDocument.Parse(json);
+        PopulateObject(document.RootElement, target, options ?? JsonSettings.SerializerSettings);
+    }
+
+    private static void PopulateObject(JsonElement element, object target, JsonSerializerOptions options)
+    {
+        if (element.ValueKind != JsonValueKind.Object || target is null)
+        {
+            return;
+        }
+
+        var properties = target.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (var jsonProp in element.EnumerateObject())
+        {
+            var prop = FindProperty(properties, jsonProp.Name);
+            if (prop is null || !prop.CanRead)
+            {
+                continue;
+            }
+
+            var propType = prop.PropertyType;
+            var jsonValue = jsonProp.Value;
+
+            // 1) Objeto anidado: reutilizar instancia existente (ObjectCreationHandling.Auto)
+            if (jsonValue.ValueKind == JsonValueKind.Object && !IsSimpleType(propType))
+            {
+                var current = prop.GetValue(target);
+                if (current is not null)
+                {
+                    PopulateObject(jsonValue, current, options);
+                    continue;
+                }
+            }
+
+            // 2) Colección existente: hacer Add (incluso si la propiedad no tiene setter)
+            if (jsonValue.ValueKind == JsonValueKind.Array && typeof(IList).IsAssignableFrom(propType))
+            {
+                if (prop.GetValue(target) is IList existing && !existing.IsReadOnly && !existing.IsFixedSize)
+                {
+                    var elementType = GetCollectionElementType(propType);
+                    foreach (var item in jsonValue.EnumerateArray())
+                    {
+                        existing.Add(DeserializeValue(item, elementType, options));
+                    }
+                    continue;
+                }
+            }
+
+            // 3) Cualquier otra cosa: requiere setter
+            if (!prop.CanWrite)
+            {
+                continue;
+            }
+
+            if (jsonValue.ValueKind == JsonValueKind.Null)
+            {
+                if (!propType.IsValueType || Nullable.GetUnderlyingType(propType) is not null)
+                {
+                    prop.SetValue(target, null);
+                }
+                continue;
+            }
+
+            prop.SetValue(target, DeserializeValue(jsonValue, propType, options));
+        }
+    }
+
+    private static object DeserializeValue(JsonElement element, Type targetType, JsonSerializerOptions options)
+    {
+        // Newtonsoft acepta enums como string (case-insensitive) por default
+        var underlying = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if (underlying.IsEnum && element.ValueKind == JsonValueKind.String)
+        {
+            var name = element.GetString();
+            return name is null ? null : Enum.Parse(underlying, name, ignoreCase: true);
+        }
+
+        return element.Deserialize(targetType, options);
+    }
+
+    private static PropertyInfo FindProperty(PropertyInfo[] properties, string jsonName)
+    {
+        PropertyInfo caseInsensitiveMatch = null;
+
+        foreach (var p in properties)
+        {
+            var name = GetJsonName(p);
+            if (name == jsonName)
+            {
+                return p; // match exacto gana
+            }
+
+            if (caseInsensitiveMatch is null &&
+                string.Equals(name, jsonName, StringComparison.OrdinalIgnoreCase))
+            {
+                caseInsensitiveMatch = p;
+            }
+        }
+
+        return caseInsensitiveMatch;
+    }
+
+    private static string GetJsonName(PropertyInfo property)
+    {
+        var attr = property.GetCustomAttribute<JsonPropertyNameAttribute>();
+        return attr?.Name ?? property.Name;
+    }
+
+    private static Type GetCollectionElementType(Type collectionType)
+    {
+        if (collectionType.IsArray)
+        {
+            return collectionType.GetElementType()!;
+        }
+
+        if (collectionType.IsGenericType)
+        {
+            var args = collectionType.GetGenericArguments();
+            if (args.Length == 1)
+            {
+                return args[0];
+            }
+        }
+
+        foreach (var iface in collectionType.GetInterfaces())
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                return iface.GetGenericArguments()[0];
+            }
+        }
+
+        return typeof(object);
+    }
+
+    private static bool IsSimpleType(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        return type.IsPrimitive
+            || type.IsEnum
+            || type == typeof(string)
+            || type == typeof(decimal)
+            || type == typeof(DateTime)
+            || type == typeof(DateTimeOffset)
+            || type == typeof(TimeSpan)
+            || type == typeof(Guid);
+    }
+}


### PR DESCRIPTION
WARNING: Needs thorough testing. It works perfectly on my end, but we should look out for potential edge cases
----------

This pull request migrates the codebase from using `Newtonsoft.Json` to the built-in `System.Text.Json` for JSON serialization and deserialization throughout the project. It updates serializer settings, replaces all usages of `JsonConvert` and related types with their `System.Text.Json` equivalents, and adjusts code to accommodate API differences. This change reduces external dependencies and leverages the improved performance and features of `System.Text.Json`.

**Migration from Newtonsoft.Json to System.Text.Json:**

- All references to `Newtonsoft.Json` and `JsonConvert` have been replaced with `System.Text.Json` and `JsonSerializer`, including serializer settings and attributes such as `[JsonProperty]` to `[JsonPropertyName]`.
- The `Newtonsoft.Json` package reference was removed from the project.
- Serializer options and settings updates
- Code and API adjustments
- Utility classes and extension methods have been updated to use the new serialization APIs and settings.

This migration streamlines JSON handling in the project, aligns with modern .NET practices, and removes a third-party dependency.