### PR TITLE
.NET 8, 9, 10 and updated external libs

### DIFF
--- a/src/Hydro.csproj
+++ b/src/Hydro.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Krzysztof Jeske</Authors>
     <Build>$([System.DateTime]::op_Subtraction($([System.DateTime]::get_Now().get_Date()),$([System.DateTime]::new(2000,1,1))).get_TotalDays())</Build>
@@ -19,13 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.50"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    <PackageReference Include="MinVer" Version="4.3.0">
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="MinVer" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -41,6 +41,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the project's target frameworks and core dependencies to align with current .NET support cycles and security standards.

**Target framework updates:**

* Updated `TargetFrameworks` to include `net8.0` (LTS), `net9.0`, and `net10.0`, removing support for `net6.0` and `net7.0` since they are deprecated.

**Dependency updates:**

* Upgraded `HtmlAgilityPack` to version `1.12.4`.
* Upgraded `Newtonsoft.Json` to version `13.0.4`.
* Upgraded `MinVer` to version `7.0.0`.